### PR TITLE
Core protocol v3.0 - data types

### DIFF
--- a/docs/protocol/core/v3.0.rst
+++ b/docs/protocol/core/v3.0.rst
@@ -126,99 +126,100 @@ Core data types
 ~~~~~~~~~~~~~~~
 
 .. list-table:: Data types
-    :header-rows: 1
-    * - Identifier
-      - Numerical type
-      - Size (no. bytes)
-      - Byte order
-    * - `bool`
-      - Boolean
-      - 1
-      - None
-    * - `i1`
-      - signed integer
-      - 1
-      - None
-    * - `<i2`
-      - signed integer
-      - 2
-      - little-endian
-    * - `<i4`
-      - signed integer
-      - 4
-      - little-endian
-    * - `<i8`
-      - signed integer
-      - 8
-      - little-endian
-    * - `>i2`
-      - signed integer
-      - 2
-      - big-endian
-    * - `>i4`
-      - signed integer
-      - 4
-      - big-endian
-    * - `>i8`
-      - signed integer
-      - 8
-      - big-endian
-    * - `u1`
-      - signed integer
-      - 1
-      - None
-    * - `<u2`
-      - unsigned integer
-      - 2
-      - little-endian
-    * - `<u4`
-      - unsigned integer
-      - 4
-      - little-endian
-    * - `<u8`
-      - unsigned integer
-      - 8
-      - little-endian
-    * - `<f2`
-      - half precision float: sign bit, 5 bits exponent, 10 bits mantissa
-      - 2
-      - little-endian
-    * - `<f4`
-      - single precision float: sign bit, 8 bits exponent, 23 bits mantissa
-      - 4
-      - little-endian
-    * - `<f8`
-      - double precision float: sign bit, 11 bits exponent, 52 bits mantissa
-      - 8
-      - little-endian
-    * - `>f2`
-      - half precision float: sign bit, 5 bits exponent, 10 bits mantissa
-      - 2
-      - big-endian
-    * - `>f4`
-      - single precision float: sign bit, 8 bits exponent, 23 bits mantissa
-      - 4
-      - big-endian
-    * - `>f8`
-      - double precision float: sign bit, 11 bits exponent, 52 bits mantissa
-      - 8
-      - big-endian
-    * - `<c8`
-      - complex number, represented by two 32-bit floats (real and imaginary components)
-      - 8
-      - little-endian
-    * - `<c16`
-      - complex number, represented by two 64-bit floats (real and imaginary components)
-      - 16
-      - little-endian
-    * - `>c8`
-      - complex number, represented by two 32-bit floats (real and imaginary components)
-      - 8
-      - big-endian
-    * - `>c16`
-      - complex number, represented by two 64-bit floats (real and imaginary components)
-      - 16
-      - big-endian
+   :header-rows: 1
+
+   * - Identifier
+     - Numerical type
+     - Size (no. bytes)
+     - Byte order
+   * - `bool`
+     - Boolean
+     - 1
+     - None
+   * - `i1`
+     - signed integer
+     - 1
+     - None
+   * - `<i2`
+     - signed integer
+     - 2
+     - little-endian
+   * - `<i4`
+     - signed integer
+     - 4
+     - little-endian
+   * - `<i8`
+     - signed integer
+     - 8
+     - little-endian
+   * - `>i2`
+     - signed integer
+     - 2
+     - big-endian
+   * - `>i4`
+     - signed integer
+     - 4
+     - big-endian
+   * - `>i8`
+     - signed integer
+     - 8
+     - big-endian
+   * - `u1`
+     - signed integer
+     - 1
+     - None
+   * - `<u2`
+     - unsigned integer
+     - 2
+     - little-endian
+   * - `<u4`
+     - unsigned integer
+     - 4
+     - little-endian
+   * - `<u8`
+     - unsigned integer
+     - 8
+     - little-endian
+   * - `<f2`
+     - half precision float: sign bit, 5 bits exponent, 10 bits mantissa
+     - 2
+     - little-endian
+   * - `<f4`
+     - single precision float: sign bit, 8 bits exponent, 23 bits mantissa
+     - 4
+     - little-endian
+   * - `<f8`
+     - double precision float: sign bit, 11 bits exponent, 52 bits mantissa
+     - 8
+     - little-endian
+   * - `>f2`
+     - half precision float: sign bit, 5 bits exponent, 10 bits mantissa
+     - 2
+     - big-endian
+   * - `>f4`
+     - single precision float: sign bit, 8 bits exponent, 23 bits mantissa
+     - 4
+     - big-endian
+   * - `>f8`
+     - double precision float: sign bit, 11 bits exponent, 52 bits mantissa
+     - 8
+     - big-endian
+   * - `<c8`
+     - complex number, represented by two 32-bit floats (real and imaginary components)
+     - 8
+     - little-endian
+   * - `<c16`
+     - complex number, represented by two 64-bit floats (real and imaginary components)
+     - 16
+     - little-endian
+   * - `>c8`
+     - complex number, represented by two 32-bit floats (real and imaginary components)
+     - 8
+     - big-endian
+   * - `>c16`
+     - complex number, represented by two 64-bit floats (real and imaginary components)
+     - 16
+     - big-endian
 
 Floating point types correspond to basic binary interchange formats as
 defined by IEEE 754-2008.

--- a/docs/protocol/core/v3.0.rst
+++ b/docs/protocol/core/v3.0.rst
@@ -133,7 +133,7 @@ Core data types
      - Size (no. bytes)
      - Byte order
    * - `bool`
-     - Boolean
+     - Boolean, with False encoded as `\x00` and True encoded as `\x01`
      - 1
      - None
    * - `i1`

--- a/docs/protocol/core/v3.0.rst
+++ b/docs/protocol/core/v3.0.rst
@@ -220,6 +220,9 @@ Core data types
       - 16
       - big-endian
 
+Floating point types correspond to basic binary interchange formats as
+defined by IEEE 754-2008.
+
 
 Regular chunk grids
 -------------------

--- a/docs/protocol/core/v3.0.rst
+++ b/docs/protocol/core/v3.0.rst
@@ -101,7 +101,125 @@ TODO define constraints on node names
 Data types
 ----------
 
-TODO define core data types
+A data type describes the set of possible binary values that an array
+element may take, along with some information about how the values
+should be interpreted.
+
+This protocol defines a limited set of data types to represent Boolean
+values, integers, floating point numbers and complex numbers. Protocol
+extensions may define additional data types. All of the data types
+defined here have a fixed size, in the sense that all values require
+the same number of bytes. However, protocol extensions may define
+variable sized data types.
+
+Note that the Zarr protocol is intended to enable communication of
+data between a variety of computing environments. The native byte
+order may differ between machines used to write and read the data.
+
+Each data type is associated with an identifier, which can be used in
+metadata documents to refer to the data type. For the data types
+defined in this protocol, the identifier is a simple ASCII
+string. However, protocol extensions may use any JSON value to
+identify a data type.
+
+Core data types
+~~~~~~~~~~~~~~~
+
+.. list-table:: Data types
+    :header-rows: 1
+    * - Identifier
+      - Numerical type
+      - Size (no. bytes)
+      - Byte order
+    * - `bool`
+      - Boolean
+      - 1
+      - None
+    * - `i1`
+      - signed integer
+      - 1
+      - None
+    * - `<i2`
+      - signed integer
+      - 2
+      - little-endian
+    * - `<i4`
+      - signed integer
+      - 4
+      - little-endian
+    * - `<i8`
+      - signed integer
+      - 8
+      - little-endian
+    * - `>i2`
+      - signed integer
+      - 2
+      - big-endian
+    * - `>i4`
+      - signed integer
+      - 4
+      - big-endian
+    * - `>i8`
+      - signed integer
+      - 8
+      - big-endian
+    * - `u1`
+      - signed integer
+      - 1
+      - None
+    * - `<u2`
+      - unsigned integer
+      - 2
+      - little-endian
+    * - `<u4`
+      - unsigned integer
+      - 4
+      - little-endian
+    * - `<u8`
+      - unsigned integer
+      - 8
+      - little-endian
+    * - `<f2`
+      - half precision float: sign bit, 5 bits exponent, 10 bits mantissa
+      - 2
+      - little-endian
+    * - `<f4`
+      - single precision float: sign bit, 8 bits exponent, 23 bits mantissa
+      - 4
+      - little-endian
+    * - `<f8`
+      - double precision float: sign bit, 11 bits exponent, 52 bits mantissa
+      - 8
+      - little-endian
+    * - `>f2`
+      - half precision float: sign bit, 5 bits exponent, 10 bits mantissa
+      - 2
+      - big-endian
+    * - `>f4`
+      - single precision float: sign bit, 8 bits exponent, 23 bits mantissa
+      - 4
+      - big-endian
+    * - `>f8`
+      - double precision float: sign bit, 11 bits exponent, 52 bits mantissa
+      - 8
+      - big-endian
+    * - `<c8`
+      - complex number, represented by two 32-bit floats (real and imaginary components)
+      - 8
+      - little-endian
+    * - `<c16`
+      - complex number, represented by two 64-bit floats (real and imaginary components)
+      - 16
+      - little-endian
+    * - `>c8`
+      - complex number, represented by two 32-bit floats (real and imaginary components)
+      - 8
+      - big-endian
+    * - `>c16`
+      - complex number, represented by two 64-bit floats (real and imaginary components)
+      - 16
+      - big-endian
+
 
 Regular chunk grids
 -------------------


### PR DESCRIPTION
This PR proposes a section of the v3.0 core protocol specification describing a set of data types for array elements.

Some discussion/decision points, for the following, should they be defined in the core protocol or via a protocol extension:

* Fixed length byte string types (corresponding to types like 'S4' in numpy for an array containing length 4 byte strings)?
* Fixed length unicode type (i.e., corresponding to types like '<U4' in numpy for an array containing length 4 unicode code points)?
* Datetime/timedelta data types (corresponding to e.g. 'M8[ns]' and 'm8[ns]' types in numpy)?
* Structured (i.e., struct-like) data types?
* Variable length data types, such as variable length arrays of a primitive type, or variable length byte or text strings?