### PR TITLE
Core protocol v3.0 - front matter

### DIFF
--- a/docs/protocol/core/v3.0.rst
+++ b/docs/protocol/core/v3.0.rst
@@ -41,7 +41,23 @@ branch.
 This document was produced by the [Zarr core development
 team](https://github.com/orgs/zarr-developers/teams/core-devs).
 
-    
+
+Document conventions
+--------------------
+
+Conformance requirements are expressed with a combination of
+descriptive assertions and [RFC2119]_ terminology. The key words
+"MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in the normative
+parts of this document are to be interpreted as described in
+[RFC2119]_. However, for readability, these words do not appear in all
+uppercase letters in this specification.
+
+All of the text of this specification is normative except sections
+explicitly marked as non-normative, examples, and notes. Examples in
+this specification are introduced with the words "for example".
+
+
 Conceptual model
 ----------------
 
@@ -190,3 +206,10 @@ Storage protocol
 TODO define how high level operations like creating a group or array 
 translate into low level key/value operations on the store interface
 
+
+References
+----------
+
+.. [RFC2119] S. Bradner. Key words for use in RFCs to Indicate
+   Requirement Levels. March 1997. Best Current Practice. URL:
+   https://tools.ietf.org/html/rfc2119

--- a/docs/protocol/core/v3.0.rst
+++ b/docs/protocol/core/v3.0.rst
@@ -13,6 +13,14 @@ Issue tracking:
 Suggest an edit for this spec:
     [GitHub editor](https://github.com/zarr-developers/zarr-specs/blob/core-protocol-v3.0-dev/docs/protocol/core/v3.0.rst)
 
+Copyright 2019 [Zarr core development
+team](https://github.com/orgs/zarr-developers/teams/core-devs) (@@TODO
+list institutions?). This work is licensed under a [Creative Commons
+Attribution 3.0 Unported
+License](https://creativecommons.org/licenses/by/3.0/).
+
+----
+
 
 Abstract
 --------

--- a/docs/protocol/core/v3.0.rst
+++ b/docs/protocol/core/v3.0.rst
@@ -7,7 +7,7 @@ This version:
     http://purl.org/zarr/spec/protocol/core/3.0/dev
     TODO replace "dev" with a git tag when a draft is tagged, and create a PURL redirecting to RTFD
 Latest version:
-    http://purl.org/zarr/spec/protocol/core/3.0/latest
+    http://purl.org/zarr/spec/protocol/core/3.0
 Issue tracking:
     [GitHub issues](https://github.com/zarr-developers/zarr-specs/labels/core-protocol-v3.0)
 Suggest an edit for this spec:

--- a/docs/protocol/core/v3.0.rst
+++ b/docs/protocol/core/v3.0.rst
@@ -4,10 +4,10 @@ Zarr core protocol version 3.0
 **Work in Progress**
 
 This version:
-    https://zarr-specs.readthedocs.io/en/core-protocol-v3.0-dev/protocol/core/v3.0.html
-    TODO replace "core-protocol-v3.0-dev" with a git tag when a snapshot version is tagged
-Latest published version:
-    https://zarr-specs.readthedocs.io/en/latest/protocol/core/v3.0.html (not yet published)
+    http://purl.org/zarr/spec/protocol/core/3.0/dev
+    TODO replace "dev" with a git tag when a draft is tagged, and create a PURL redirecting to RTFD
+Latest version:
+    http://purl.org/zarr/spec/protocol/core/3.0/latest
 Issue tracking:
     [GitHub issues](https://github.com/zarr-developers/zarr-specs/labels/core-protocol-v3.0)
 Suggest an edit for this spec:

--- a/docs/protocol/core/v3.0.rst
+++ b/docs/protocol/core/v3.0.rst
@@ -1,7 +1,7 @@
 Zarr core protocol version 3.0
 ==============================
 
-**Work in progress**
+**Work in Progress**
 
 This version:
     https://zarr-specs.readthedocs.io/en/core-protocol-v3.0-dev/protocol/core/v3.0.html

--- a/docs/protocol/core/v3.0.rst
+++ b/docs/protocol/core/v3.0.rst
@@ -1,3 +1,6 @@
+.. This file is in restructured text format: http://docutils.sourceforge.net/rst.html
+
+
 Zarr core protocol version 3.0
 ==============================
 

--- a/docs/protocol/core/v3.0.rst
+++ b/docs/protocol/core/v3.0.rst
@@ -1,7 +1,47 @@
 Zarr core protocol version 3.0
 ==============================
 
+**Work in progress**
 
+This version:
+    https://zarr-specs.readthedocs.io/en/core-protocol-v3.0-dev/protocol/core/v3.0.html
+    TODO replace "core-protocol-v3.0-dev" with a git tag when a snapshot version is tagged
+Latest published version:
+    https://zarr-specs.readthedocs.io/en/latest/protocol/core/v3.0.html (not yet published)
+Issue tracking:
+    [GitHub issues](https://github.com/zarr-developers/zarr-specs/labels/core-protocol-v3.0)
+Suggest an edit for this spec:
+    [GitHub editor](https://github.com/zarr-developers/zarr-specs/blob/core-protocol-v3.0-dev/docs/protocol/core/v3.0.rst)
+
+
+Abstract
+--------
+
+This specification defines a core protocol for storage and retrieval
+of N-dimensional typed arrays.
+
+
+Status of this document
+-----------------------
+
+This document is a **Work in Progress**. It may be updated, replaced
+or obsoleted by other documents at any time. It is inappapropriate to
+cite this document as other than work in progress.
+
+Comments, questions or contributions to this document are very
+welcome. Comments and questions should be raised via [GitHub
+issues](https://github.com/zarr-developers/zarr-specs/labels/core-protocol-v3.0). When
+raising an issue, please add the label
+"core-protocol-v3.0". Contributions and suggested edits can be made
+via GitHub via the [online
+editor](https://github.com/zarr-developers/zarr-specs/blob/core-protocol-v3.0-dev/docs/protocol/core/v3.0.rst)
+or by making a pull request against the "core-protocol-v3.0-dev"
+branch.
+
+This document was produced by the [Zarr core development
+team](https://github.com/orgs/zarr-developers/teams/core-devs).
+
+    
 Conceptual model
 ----------------
 


### PR DESCRIPTION
This PR suggests some front matter for the spec. Based on front matter used in W3C specs, e.g. [css-nav](https://www.w3.org/TR/2019/WD-css-nav-1-20190423/).