### PR TITLE
Core protocol v3.0 - illustrate data type extension (datetimes and timedeltas)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,3 +50,8 @@ html_theme = 'alabaster'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+suppress_warnings = [
+    # suppress "duplicate citation" warnings
+    'ref.citation',
+]

--- a/docs/protocol/core/v3.0.rst
+++ b/docs/protocol/core/v3.0.rst
@@ -699,6 +699,33 @@ compression prior to storage::
 	}
     }
 
+The following example illustrates an array with the same shape and
+chunking as above, but using an extension data type::
+
+    {
+        "zarr_format": "http://purl.org/zarr/spec/protocol/core/3.0",
+	"shape": [10000, 1000],
+	"data_type": {
+	    "extension": "http://purl.org/zarr/spec/protocol/extensions/datetime-dtypes/1.0",
+	    "type": "<M8[ns]",
+	    "fallback": "<i8"
+	},
+	"chunk_grid": {
+	    "type": "regular",
+	    "chunk_shape": [1000, 100]
+	},
+	"chunk_memory_layout": "C",
+	"chunk_codecs": [
+            {
+	        "codec": "http://purl.org/zarr/spec/codec/gzip",
+		"level": 1
+	    }
+	],
+	"fill_value": null,
+	"extensions": [],
+	"attributes": {}
+    }
+
 
 Group metadata
 ~~~~~~~~~~~~~~

--- a/docs/protocol/extensions.rst
+++ b/docs/protocol/extensions.rst
@@ -7,5 +7,5 @@ Under construction.
    :maxdepth: 1
    :caption: Contents:
 
-   extensions/example/v1.0
+   extensions/datetime-dtypes/v1.0
 

--- a/docs/protocol/extensions/datetime-dtypes/v1.0.rst
+++ b/docs/protocol/extensions/datetime-dtypes/v1.0.rst
@@ -1,0 +1,154 @@
+Datetime data types version 1.0
+===============================
+
+**Work in Progress**
+
+Specification URI:
+    http://purl.org/zarr/spec/protocol/extensions/datetime-dtypes/1.0
+Issue tracking:
+    `GitHub issues <https://github.com/zarr-developers/zarr-specs/labels/datetime-dtypes-v1.0>`_
+Suggest an edit for this spec:
+    `GitHub editor <https://github.com/zarr-developers/zarr-specs/blob/core-protocol-v3.0-dev/docs/protocol/extension/datetime-dtypes/v1.0.rst>`_
+
+Copyright 2019 `Zarr core development
+team <https://github.com/orgs/zarr-developers/teams/core-devs>`_ (@@TODO
+list institutions?). This work is licensed under a `Creative Commons
+Attribution 3.0 Unported
+License <https://creativecommons.org/licenses/by/3.0/>`_.
+
+----
+
+
+Abstract
+--------
+
+This specification is a Zarr protocol extension defining data types
+for datetimes (moment in time) and timedeltas (difference between two
+datetimes).
+
+
+Status of this document
+-----------------------
+
+This document is a **Work in Progress**. It may be updated, replaced
+or obsoleted by other documents at any time. It is inappapropriate to
+cite this document as other than work in progress.
+
+Comments, questions or contributions to this document are very
+welcome. Comments and questions should be raised via `GitHub issues
+<https://github.com/zarr-developers/zarr-specs/labels/datetime-dtypes-v1.0>`_. When
+raising an issue, please add the label "datetime-dtypes-v1.0".
+
+This document was produced by the `Zarr core development team
+<https://github.com/orgs/zarr-developers/teams/core-devs>`_.
+
+
+Document conventions
+--------------------
+
+Conformance requirements are expressed with a combination of
+descriptive assertions and [RFC2119]_ terminology. The key words
+"MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in the normative
+parts of this document are to be interpreted as described in
+[RFC2119]_. However, for readability, these words do not appear in all
+uppercase letters in this specification.
+
+All of the text of this specification is normative except sections
+explicitly marked as non-normative, examples, and notes. Examples in
+this specification are introduced with the words "for example".
+
+
+Extension data types
+--------------------
+
+Two extension data types are defined to represent datetime and
+timedelta values. The definitions of these data types are based on the
+datetime64 and timedelta64 data types as described in [NumPy]_, but
+are intended to be portable across Zarr implementations in different
+programming languages.
+
+Datetime
+~~~~~~~~
+
+The datetime data type represents a single moment in time. It is a
+logical data type based on the 64-bit integer data type, with
+associated `Units`_. Datetimes are always stored based on POSIX time,
+with an epoch of 1970-01-01T00:00Z. This means the supported dates are
+always a symmetric interval around the epoch, called "time span" in
+the `Units`_ table below.
+
+The length of the span is the range of a 64-bit integer times the
+length of the date or unit. For example, the time span for 'W' (week)
+is exactly 7 times longer than the time span for 'D' (day), and the
+time span for 'D' (day) is exactly 24 times longer than the time span
+for 'h' (hour).
+
+Timedelta
+~~~~~~~~~
+
+The timedelta data type represents a difference between two
+datatimes. It is a logical data type based on the 64-bit integer data
+type, with associated `Units`_. Note that two timedelta units ('Y',
+years and 'M', months) represent different amounts of time depending
+on when they are used. E.g., While a timedelta day unit is equivalent
+to 24 hours, there is no way to convert a month unit into days,
+because different months have different numbers of days.
+
+
+Units
+-----
+
+====  ============  ====================  ======================
+Code  Meaning       Time span (relative)  Time span (absolute)
+====  ============  ====================  ======================
+Y     year          +/- 9.2e18 years      [9.2e18 BC, 9.2e18 AD]
+M     month         +/- 7.6e17 years      [7.6e17 BC, 7.6e17 AD]
+W     week          +/- 1.7e17 years      [1.7e17 BC, 1.7e17 AD]
+D     day           +/- 2.5e16 years      [2.5e16 BC, 2.5e16 AD]
+h     hour          +/- 1.0e15 years      [1.0e15 BC, 1.0e15 AD]
+m     minute        +/- 1.7e13 years      [1.7e13 BC, 1.7e13 AD]
+s     second        +/- 2.9e11 years      [2.9e11 BC, 2.9e11 AD]
+ms    millisecond   +/- 2.9e8 years       [ 2.9e8 BC, 2.9e8 AD]
+us    microsecond   +/- 2.9e5 years       [290301 BC, 294241 AD]
+ns    nanosecond    +/- 292 years         [1678 AD, 2262 AD]
+ps    picosecond    +/- 106 days          [1969 AD, 1970 AD]
+fs    femtosecond   +/- 2.6 hours         [1969 AD, 1970 AD]
+as    attosecond    +/- 9.2 seconds       [1969 AD, 1970 AD]
+====  ============  ====================  ======================
+
+
+Data type identifiers
+---------------------
+
+An identifier for a datetime data type is constructed from the string
+pattern "[endianness]M8[[units]]" where `endianness` is either "<"
+(little-endian) or ">" (big-endian) and `units` is one of the unit
+codes defined above. The endianness and units must be given. E.g.,
+"<M8[ns]" identifies a little-endian datatime data type with
+nanosecond units.
+
+An identifier for a timedelta data type is constructed from the string
+pattern "[endianness]m8[[units]]" where `endianness` is either "<"
+(little-endian) or ">" (big-endian) and `units` is one of the unit
+codes defined above. The endianness and units must be given. E.g.,
+"<m8[ns]" identifies a little-endian timedelta data type with
+nanosecond units.
+
+
+References
+----------
+
+.. [RFC2119] S. Bradner. Key words for use in RFCs to Indicate
+   Requirement Levels. March 1997. Best Current Practice. URL:
+   https://tools.ietf.org/html/rfc2119
+
+.. [NumPy] NumPy Datetimes and Timedeltas. NumPy version 1.16.0
+   documentation. URL:
+   https://docs.scipy.org/doc/numpy-1.16.0/reference/arrays.datetime.html
+
+				    
+Change log
+----------
+
+@@TODO

--- a/docs/protocol/extensions/example/v1.0.rst
+++ b/docs/protocol/extensions/example/v1.0.rst
@@ -1,4 +1,0 @@
-Example protocol extension version 1.0
-======================================
-
-A Zarr protocol extension would live in a location like this.


### PR DESCRIPTION
This PR is intended to provide an illustration of how protocol extensions that define new data types would be documented and used together with the v3.0 protocol.

This PR uses the example of datatime and timedelta data types. This is meant for illustration only at this stage. 