### PR TITLE
Fix rendering of allowed characters.

### DIFF
--- a/docs/protocol/core/v3.0.rst
+++ b/docs/protocol/core/v3.0.rst
@@ -263,8 +263,8 @@ node names:
 
 * must not be the empty string ("")
 
-* must consist only of characters in the sets `a-z`, `A-Z`, `0-9`,
-  `-_.`
+* must consist only of characters in the sets ``a-z``, ``A-Z``, ``0-9``,
+  ``-_.``
 
 * must not be a string composed only of period characters, e.g. "." or
   ".."


### PR DESCRIPTION
The default rule for sphinx with simple backticks seem to be "cite",
which is rendered in italic, making it relatively hard to distinguish
what is the set of characters meant vs, formatting.

On my initial read on current page I actually though the trailing dot
was finishing the sentence, and it was not clear whether or not spaces
(and or commas) were part of allowed character.

With the double quote each character group is rendered: monospace, and in
a different color (for current theme)

--- 


Sidenote, I see no mention of encoding in this section, I'm guessing this character set has been chosen to be "safe" in the sens ascii-compatible right ? In which case you might want to actually specify the bytes range maybe as not all encoding will get these as the same bytes:

```
In [1]: from string import ascii_letters, digits
In [2]: (ascii_letters + digits).encode().decode('utf16')
Out[2]: '扡摣晥桧橩汫湭灯牱瑳癵硷穹䉁䑃䙅䡇䩉䱋乍偏剑呓噕塗婙\u3130㌲㔴㜶㤸'
```