### PR TITLE
Metadata Key suffixes

### DIFF
--- a/docs/protocol/core/v3.0.rst
+++ b/docs/protocol/core/v3.0.rst
@@ -736,6 +736,16 @@ containing the following names:
     For document using the default JSON encoding and format describe in this document
     then the value must be ``"https://purl.org/zarr/spec/protocol/core/3.0``.
 
+``metadata_key_suffix``
+
+    A string containing a suffix to add to the metadata keys when saving into
+    the store. By default ``".json"``.
+
+    .. note::
+
+      This suffix is used is used to allow non hierarchy
+      browsing and edditign by non-zarr-aware tools.
+
 ``extensions``
 
     An array containing zero or more objects, each of which identifies
@@ -762,6 +772,7 @@ JSON is being used for encoding of group and array metadata::
     {
         "zarr_format": "https://purl.org/zarr/spec/protocol/core/3.0",
         "metadata_encoding": "https://purl.org/zarr/spec/protocol/core/3.0",
+        "metadata_key_suffix" : ".json",
         "extensions": []
     }
 
@@ -772,6 +783,7 @@ ignored if not understood::
     {
         "zarr_format": "https://purl.org/zarr/spec/protocol/core/3.0",
         "metadata_encoding": "https://purl.org/zarr/spec/protocol/core/3.0",
+        "metadata_key_suffix" : ".json",
         "extensions": [
             {
                 "extension": "http://example.org/zarr/extension/foo",


### PR DESCRIPTION

  Closes #63

The rational is that backends may be explored by non zarr-aware tools,
like a filesytem and a GUI browser like Finder/Explorer/Nautilus, and
the `.json` extension will help to view/edit json in those.

While it may seem like this shoudl be store specific, once again the
fact that a zarr-hierarchy can be copied from one storage to another by
non-zarr-aware tool indicate that this shoudl be handled above the sotre
level.
