### PR TITLE
Add minimal drafts of a few more dtype extensions

### DIFF
--- a/docs/protocol/extensions.rst
+++ b/docs/protocol/extensions.rst
@@ -11,6 +11,7 @@ Under construction.
    extensions/filters/v1.0
    extensions/complex-dtypes/v1.0
    extensions/datetime-dtypes/v1.0
+   extensions/object-dtypes/v1.0
    extensions/string-dtypes/v1.0
    extensions/struct-dtypes/v1.0
 

--- a/docs/protocol/extensions.rst
+++ b/docs/protocol/extensions.rst
@@ -12,6 +12,7 @@ Under construction.
    extensions/complex-dtypes/v1.0
    extensions/datetime-dtypes/v1.0
    extensions/string-dtypes/v1.0
+   extensions/struct-dtypes/v1.0
 
 
 A number of other features might be included in the core protocol v3, but are currently considered as extensions. 

--- a/docs/protocol/extensions.rst
+++ b/docs/protocol/extensions.rst
@@ -11,6 +11,7 @@ Under construction.
    extensions/filters/v1.0
    extensions/complex-dtypes/v1.0
    extensions/datetime-dtypes/v1.0
+   extensions/string-dtypes/v1.0
 
 
 A number of other features might be included in the core protocol v3, but are currently considered as extensions. 

--- a/docs/protocol/extensions/object-dtypes/v1.0.rst
+++ b/docs/protocol/extensions/object-dtypes/v1.0.rst
@@ -1,0 +1,105 @@
+===================================
+ String data types (version 1.0)
+===================================
+-----------------------------
+ Editor's draft 2 March 2022
+-----------------------------
+
+Specification URI:
+    http://purl.org/zarr/spec/protocol/extensions/object-dtypes/1.0
+Issue tracking:
+    `GitHub issues <https://github.com/zarr-developers/zarr-specs/labels/object-dtypes-v1.0>`_
+Suggest an edit for this spec:
+    `GitHub editor <https://github.com/zarr-developers/zarr-specs/blob/core-protocol-v3.0-dev/docs/protocol/extension/object-dtypes/v1.0.rst>`_
+
+Copyright 2022 `Zarr core development
+team <https://github.com/orgs/zarr-developers/teams/core-devs>`_ (@@TODO
+list institutions?). This work is licensed under a `Creative Commons
+Attribution 3.0 Unported
+License <https://creativecommons.org/licenses/by/3.0/>`_.
+
+----
+
+
+Abstract
+========
+
+This specification is a Zarr protocol extension defining a data type where each
+element is an arbitrary Python object.
+
+
+Status of this document
+=======================
+
+This document is a **Work in Progress**. It may be updated, replaced
+or obsoleted by other documents at any time. It is inappapropriate to
+cite this document as other than work in progress.
+
+Comments, questions or contributions to this document are very
+welcome. Comments and questions should be raised via `GitHub issues
+<https://github.com/zarr-developers/zarr-specs/labels/object-dtypes-v1.0>`_. When
+raising an issue, please add the label "object-dtypes-v1.0".
+
+This document was produced by the `Zarr core development team
+<https://github.com/orgs/zarr-developers/teams/core-devs>`_.
+
+
+Document conventions
+====================
+
+Conformance requirements are expressed with a combination of
+descriptive assertions and [RFC2119]_ terminology. The key words
+"MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in the normative
+parts of this document are to be interpreted as described in
+[RFC2119]_. However, for readability, these words do not appear in all
+uppercase letters in this specification.
+
+All of the text of this specification is normative except sections
+explicitly marked as non-normative, examples, and notes. Examples in
+this specification are introduced with the words "for example".
+
+
+Object data types
+=================
+NumPy's object arrays are arrays where each element is an arbitrary Python
+object. The array elements correspond to the
+`numpy.object_ <https://numpy.org/doc/1.22/reference/arrays.scalars.html#numpy.object_>`
+type which has character code `'O'`. A common concrete use case for this type
+is to have an array where each element is another array (and each array can
+have a different length). Another use case is to store an array of variable
+length strings. It is important to note that such an array actually just stores the references to the Python objects and not the objects themselves. Accessing
+an element of the array returns the Python object it refers to.
+
+Data Types added by this extension
+==================================
+
+.. list-table:: Data types
+   :header-rows: 1
+
+   * - Identifier
+     - Numerical type
+     - Size (no. bytes)
+     - Byte order
+   * - ``O`` (uppercase letter o)
+     - 8 (TODO: I assume this is actually a hardware-dependent memory address size?)
+     - address of a Python object
+     - None
+
+
+References
+==========
+
+.. [NumPy] NumPy Data type objects. NumPy version 1.22.0
+   documentation. URL:
+   https://numpy.org/doc/1.22/reference/arrays.dtypes.html
+
+.. [H5Py variable length strings] Variable length strings
+   documentation. URL:
+   https://docs.h5py.org/en/stable/special.html#variable-length-strings
+
+Change log
+==========
+
+@@TODO
+

--- a/docs/protocol/extensions/string-dtypes/v1.0.rst
+++ b/docs/protocol/extensions/string-dtypes/v1.0.rst
@@ -1,0 +1,136 @@
+===================================
+ String data types (version 1.0)
+===================================
+-----------------------------
+ Editor's draft 2 March 2022
+-----------------------------
+
+Specification URI:
+    http://purl.org/zarr/spec/protocol/extensions/string-dtypes/1.0
+Issue tracking:
+    `GitHub issues <https://github.com/zarr-developers/zarr-specs/labels/string-dtypes-v1.0>`_
+Suggest an edit for this spec:
+    `GitHub editor <https://github.com/zarr-developers/zarr-specs/blob/core-protocol-v3.0-dev/docs/protocol/extension/string-dtypes/v1.0.rst>`_
+
+Copyright 2022 `Zarr core development
+team <https://github.com/orgs/zarr-developers/teams/core-devs>`_ (@@TODO
+list institutions?). This work is licensed under a `Creative Commons
+Attribution 3.0 Unported
+License <https://creativecommons.org/licenses/by/3.0/>`_.
+
+----
+
+
+Abstract
+========
+
+This specification is a Zarr protocol extension defining data types
+for strings. It is an early draft and currently just describes existing support
+for NumPy string types that have already worked with zarr-python, but are not
+part of the core v3 spec.
+
+
+Status of this document
+=======================
+
+This document is a **Work in Progress**. It may be updated, replaced
+or obsoleted by other documents at any time. It is inappapropriate to
+cite this document as other than work in progress.
+
+Comments, questions or contributions to this document are very
+welcome. Comments and questions should be raised via `GitHub issues
+<https://github.com/zarr-developers/zarr-specs/labels/string-dtypes-v1.0>`_. When
+raising an issue, please add the label "string-dtypes-v1.0".
+
+This document was produced by the `Zarr core development team
+<https://github.com/orgs/zarr-developers/teams/core-devs>`_.
+
+
+Document conventions
+====================
+
+Conformance requirements are expressed with a combination of
+descriptive assertions and [RFC2119]_ terminology. The key words
+"MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in the normative
+parts of this document are to be interpreted as described in
+[RFC2119]_. However, for readability, these words do not appear in all
+uppercase letters in this specification.
+
+All of the text of this specification is normative except sections
+explicitly marked as non-normative, examples, and notes. Examples in
+this specification are introduced with the words "for example".
+
+
+Extension data types
+====================
+
+Two extension data types are defined to represent zero-terminated bytestrings as
+well as fixed-length 32-bit unicode arrays.
+
+Fixed length byte strings (zero-terminated)
+-------------------------------------------
+
+These are fixed width strings corresponding to NumPy dtypes with `kind` 'S'.
+For backward compatibility with Python 2's ``str`` these are zero-terminated
+bytes and correspond to
+`numpy.bytes_ <https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.bytes_>`
+(or its alias
+`numpy.string_ <https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.bytes_>`.)
+
+For example ``a = np.array(["a", "bcd", "efgh"], dtype="S4")`` creates an array where ``a.dtype.kind`` is 'S' and ``a.data.tobytes()`` is ``b'a\x00\x00\x00bcd\x00efgh'``. Note that any elements of length less than 4 characters were padded with zeros so that each array element uses 4 bytes (as
+indicated by ``dtype="S4"``).
+
+
+Fixed width unicode strings
+---------------------------
+
+These are fixed width strings corresponding to NumPy dtypes with `kind` 'U'.
+These are zero-terminated bytes and correspond to
+`numpy.str_ <https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.str_>`
+(or its alias
+`numpy.unicode_ <https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.unicode_>`.)
+
+For example ``a = np.array(["a", "bcd", "efgh"], dtype="U4")`` creates an array where ``a.dtype.kind`` is 'U' and each element is a sequence of 4 characters where each character occupies 4 bytes (UTF-32).
+
+
+Units
+=====
+
+.. list-table:: Data types
+   :header-rows: 1
+
+   * - Identifier
+     - Numerical type
+     - Size (no. bytes)
+     - Byte order
+   * - ``Sn``
+     - ``n`` character fixed-width byte string
+     - n
+     - None
+   * - ``<Un``
+     - ``n`` character fixed-width unicode string (UTF-32)
+     - 4n
+     - little-endian
+   * - ``>Un``
+     - ``n`` character fixed-width unicode string (UTF-32)
+     - 4n
+     - big-endian
+
+
+References
+==========
+
+.. [UTF-32] UTF-32 on Wikipedia.
+   documentation. URL:
+   https://en.wikipedia.org/wiki/UTF-32
+
+.. [NumPy] NumPy Data type objects. NumPy version 1.22.0
+   documentation. URL:
+   https://numpy.org/doc/1.22/reference/arrays.dtypes.html
+
+				    
+Change log
+==========
+
+@@TODO

--- a/docs/protocol/extensions/string-dtypes/v1.0.rst
+++ b/docs/protocol/extensions/string-dtypes/v1.0.rst
@@ -94,8 +94,8 @@ These are zero-terminated bytes and correspond to
 For example ``a = np.array(["a", "bcd", "efgh"], dtype="U4")`` creates an array where ``a.dtype.kind`` is 'U' and each element is a sequence of 4 characters where each character occupies 4 bytes (UTF-32).
 
 
-Units
-=====
+Data Types added by this extension
+==================================
 
 .. list-table:: Data types
    :header-rows: 1

--- a/docs/protocol/extensions/struct-dtypes/v1.0.rst
+++ b/docs/protocol/extensions/struct-dtypes/v1.0.rst
@@ -1,0 +1,127 @@
+===================================
+ String data types (version 1.0)
+===================================
+-----------------------------
+ Editor's draft 2 March 2022
+-----------------------------
+
+Specification URI:
+    http://purl.org/zarr/spec/protocol/extensions/struct-dtypes/1.0
+Issue tracking:
+    `GitHub issues <https://github.com/zarr-developers/zarr-specs/labels/struct-dtypes-v1.0>`_
+Suggest an edit for this spec:
+    `GitHub editor <https://github.com/zarr-developers/zarr-specs/blob/core-protocol-v3.0-dev/docs/protocol/extension/struct-dtypes/v1.0.rst>`_
+
+Copyright 2022 `Zarr core development
+team <https://github.com/orgs/zarr-developers/teams/core-devs>`_ (@@TODO
+list institutions?). This work is licensed under a `Creative Commons
+Attribution 3.0 Unported
+License <https://creativecommons.org/licenses/by/3.0/>`_.
+
+----
+
+
+Abstract
+========
+
+This specification is a Zarr protocol extension defining data types
+for structured arrays. It is an early draft and currently just describes existing support for NumPy-style `structured arrays`_ that already have support in
+zarr-python, but are not part of the core Zarr v3 spec.
+
+
+Status of this document
+=======================
+
+This document is a **Work in Progress**. It may be updated, replaced
+or obsoleted by other documents at any time. It is inappapropriate to
+cite this document as other than work in progress.
+
+Comments, questions or contributions to this document are very
+welcome. Comments and questions should be raised via `GitHub issues
+<https://github.com/zarr-developers/zarr-specs/labels/struct-dtypes-v1.0>`_. When
+raising an issue, please add the label "struct-dtypes-v1.0".
+
+This document was produced by the `Zarr core development team
+<https://github.com/orgs/zarr-developers/teams/core-devs>`_.
+
+
+Document conventions
+====================
+
+Conformance requirements are expressed with a combination of
+descriptive assertions and [RFC2119]_ terminology. The key words
+"MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in the normative
+parts of this document are to be interpreted as described in
+[RFC2119]_. However, for readability, these words do not appear in all
+uppercase letters in this specification.
+
+All of the text of this specification is normative except sections
+explicitly marked as non-normative, examples, and notes. Examples in
+this specification are introduced with the words "for example".
+
+
+Extension data types
+====================
+
+NumPy allows representation of `Structured Arrays`_ where each element of the
+array is actually some combination of fields, each of which may have its own
+unique data type. NumPy's Record Arrays (``numpy.recarray``) also use this data type. The actual data is stored as an opaque seqeuence of bytes
+(i.e. a structure) as represented by (``numpy.void``) and thus the string
+representation of this dtype in NumPy is ``'|Vn'`` where ``n`` is some integer
+number of bytes. In order to be able to properly interpret data of this type
+if is necessary to store information on the fields
+
+A concrete example of such an array from the NumPy docs is::
+
+    dogs = np.array([('Rex', 9, 81.0), ('Fido', 3, 27.0)],
+                    dtype=[('name', 'U10'), ('age', 'i4'), ('weight', 'f4')])
+
+where here ``dogs.dtype.kind`` is 'V' and ``dogs.dtype.str`` is ``'|V48'``
+indicating the 48 bytes are needed to store each element (4 bytes each for
+``age`` and ``weight`` and 4 * 10 = 40 bytes for a 10-character UTF-32
+``name``). If we were to read such a sequence of bytes from a Zarr array, we
+need the dtype description to know how to properly interpret this sequence of
+48 bytes. The NumPy dtype object has a ``descr`` attribute that describes this.
+In this case ``dogs.dtype.descr`` is ``[('name', '<U10'), ('age', '<i4'), ('weight', '<f4')]``.
+
+
+Data Types added by this extension
+==================================
+
+.. list-table:: Data types
+   :header-rows: 1
+
+   * - Identifier
+     - Numerical type
+     - Size (no. bytes)
+     - Byte order
+   * - list of (<name>, <type>) tuples
+     - structure with named fields, each with possibly unique data type
+     - sum over the size of the dtypes in the identifier
+     - None
+
+Here <field name> is the name of the struct field and <type> is any of the
+scalar dtypes supported by the core Zarr v3 spec or the available extensions.
+In the case of NumPy's structured arrays this identifier is simply
+array's ``.dtype.descr`` attribute.
+
+
+References
+==========
+
+.. [NumPy] NumPy Data type objects. NumPy version 1.22.0
+   documentation. URL:
+   https://numpy.org/doc/1.22/reference/arrays.dtypes.html
+
+.. [NumPy Structured] Structured Arrays.
+   documentation. URL:
+   https://numpy.org/doc/1.22/user/basics.rec.html
+
+Change log
+==========
+
+@@TODO
+
+
+.. _structured arrays: https://numpy.org/doc/1.22/user/basics.rec.html


### PR DESCRIPTION
This adds draft extensions for the remaining dtypes supported for Zarr v2 arrays in zarr-python that are not part of the core v3 spec. Merging this would at least give us a URL to point to for these dtypes in https://github.com/zarr-developers/zarr-python/pull/898.

The language here will eventually need updating to be more spec-like and more implementation neutral (e.g. less NumPy/Python specific). What is there now, at least describes the current behavior in zarr-python.

In the last community call @jbms (from from the [tensorstore](https://google.github.io/tensorstore/) team) mentioned that NumPy's fixed width unicode arrays are not very desirable and variable length strings are likely of more interest. There is not a variable length string dtype in NumPy, but variable length strings can be stored as object arrays ([H5Py for example does this](https://docs.h5py.org/en/stable/special.html#variable-length-strings)). I know Pandas 1.0 also introduced their own `StringDType`, but I haven't looked into the specifics of that.
