### PR TITLE
Revise how the domain of an array is specified

### DIFF
--- a/docs/core/v3.0.rst
+++ b/docs/core/v3.0.rst
@@ -243,11 +243,9 @@ conceptual model underpinning the Zarr format.
 
 *Array*
 
-    An array is a node in a hierarchy_. An array is a data structure
-    with zero or more dimensions_ whose lengths define the shape_ of
-    the array. An array contains zero or more data elements_. All
-    elements_ in an array conform to the same `data type`_. An array
-    may not have child nodes.
+    An array is a node in a hierarchy_. An array is a data structure that maps
+    each index vector contained in its domain_ to an element_ value that is
+    supported by its `data type`_.  An array may not have child nodes.
 
 .. _name:
 .. _names:
@@ -278,26 +276,24 @@ conceptual model underpinning the Zarr format.
     QUESTION: do we want to codify that group ``path`` end, can end, or must end
     in ``/`` ?
 
+.. _domain:
+
+*Domain*
+
+    Specifies the space of index vectors that an array_ maps to values.  The
+    domain specifies an integer lower and upper bound for each dimension_, as
+    well as an optional `dimension name`_.
+
 .. _dimension:
 .. _dimensions:
 
 *Dimension*
 
     An array_ has a fixed number of zero or more dimensions. Each
-    dimension has an integer length. This specification only considers
-    the case where the lengths of all dimensions are finite. However,
+    dimension has an integer lower and upper bound. This specification only considers
+    the case where the lower and upper bounds of all dimensions are finite. However,
     `extensions`_ may be defined which allow a dimension to have
-    an infinite or variable length.
-
-.. _shape:
-
-*Shape*
-
-    The shape of an array_ is the tuple of dimension_ lengths. For
-    example, if an array_ has 2 dimensions_, where the length of the
-    first dimension_ is 100 and the length of the second dimension_ is
-    20, then the shape of the array_ is (100, 20). A shape can be the empty
-    tuple in the case of zero-dimension arrays (scalar)
+    infinite bounds, or variable bounds dependent on indices within other dimensions.
 
 .. _element:
 .. _elements:
@@ -393,7 +389,7 @@ conceptual model underpinning the Zarr format.
     Each array_ in a hierarchy_ is represented by a metadata document,
     which is a machine-readable document containing essential
     processing information about the node. For example, an array_
-    metadata document will specify the number of dimensions_, shape_,
+    metadata document will specify the domain_,
     `data type`_, grid_, `memory layout`_ and compressor_ for that
     array_.
 
@@ -631,73 +627,53 @@ chunk data in a store, see also the `Storage`_ section.
 Regular grids
 -------------
 
-A regular grid is a type of grid where an array is divided into chunks
-such that each chunk is a hyperrectangle of the same shape. The
-dimensionality of the grid is the same as the dimensionality of the
-array. Each chunk in the grid can be addressed by a tuple of positive
-integers (`k`, `j`, `i`, ...) corresponding to the indices of the
-chunk along each dimension.
+A regular grid is a type of grid where an array is divided into chunks such that
+each chunk is a hyperrectangle of the same shape.  The dimensionality of the
+grid is the same as the dimensionality of the array.  The grid is defined by 3
+parameters:
 
-The origin vertex of a chunk has coordinates in the array space (`k` *
-`dz`, `j` * `dy`, `i` * `dx`, ...) where (`dz`, `dy`, `dx`, ...) are
-the chunk sizes along each dimension.
-Thus the origin vertex of the chunk at grid index (0, 0, 0,
-...) is at coordinate (0, 0, 0, ...) in the array space, i.e., the
-grid is aligned with the origin of the array. If the length of any
-array dimension is not perfectly divisible by the chunk length along
-the same dimension, then the grid will overhang the edge of the array
-space.
+- the integer ``chunk_shape`` vector specifying the shape of each chunk/grid
+  cell;
+- the integer ``grid_origin`` vector specifying the origin of the grid within
+  the domain_;
+- the ``separator`` specifying how grid cell indices are encoded as storage
+  keys.
 
-The shape of the chunk grid will be (ceil(`z` / `dz`), ceil(`y` /
-`dy`), ceil(`x` / `dx`), ...)  where (`z`, `y`, `x`, ...) is the array
-shape, "/" is the division operator and "ceil" is the ceiling
-function. For example, if a 3 dimensional array has shape (10, 200,
-3000), and has chunk shape (5, 20, 400), then the shape of the chunk
-grid will be (2, 10, 8), meaning that there will be 2 chunks along the
-first dimension, 10 along the second dimension, and 8 along the third
-dimension.
+The ``chunk_shape`` and ``grid_origin`` vectors must have the same number of
+dimensions as the array.
 
-.. list-table:: Regular Grid Example
-    :header-rows: 1
+Each chunk in the grid can be addressed by a vector of integers
+``cell_indices``.  The starting position ``indices`` (inclusive) within the
+domain of the chunk is given by:
 
-    * - Array Shape
-      - Chunk Shape
-      - Chunk Grid Shape
-      - Notes
-    * - (10, 200, 3000)
-      - (5, 20, 400)
-      - (2, 10, 8)
-      - The grid does overhang the edge of the array on the 3rd dimension.
+``indices[i] = grid_origin[i] + cell_indices[i] * chunk_shape[i]``
 
-An element of an array with coordinates (`c`, `b`, `a`, ...) will
-occur within the chunk at grid index (`c` // `dz`, `b` // `dy`, `a` //
-`dx`, ...), where "//" is the floor division operator. The element
-will have coordinates (`c` % `dz`, `b` % `dy`, `a` % `dx`, ...) within
-that chunk, where "%" is the modulo operator. For example, if a
-3 dimensional array has shape (10, 200, 3000), and has chunk shape
-(5, 20, 400), then the element of the array with coordinates (7, 150, 900)
-is contained within the chunk at grid index (1, 7, 2) and has coordinates
-(2, 10, 100) within that chunk.
+The ending position ``indices`` (exclusive) within the domain is given by:
 
+``indices[i] = grid_origin[i] + (cell_indices[i] + 1) * chunk_shape[i]``
 
-The identifier for chunk with grid index (``k``, ``j``, ``i``, ...) is
-formed by joining together ASCII string representations of each index
-using a separator and prefixed with the character ``c``. The default value for
-the separator is the slash character, ``/``, but this may be configured by
-providing a ``separator`` value within the ``chunk_grid`` metadata object (see
-the section on `Array metadata`_ below).
+Conversely, given an integer index vector ``indices`` within the domain_, the
+corresponding ``cell_indices`` vector is given by:
+
+``cell_indices[i] = floor((indices[i] - grid_origin[i]) / chunk_shape[i])``
+
+For given ``inclusive_min`` and ``exclusive_max`` bounds of the domain_, the
+corresponding bounds on the grid ``cell_indices`` are given by:
+
+``grid_inclusive_min[i] = floor((inclusive_min[i] - grid_origin[i]) / chunk_shape[i])``
+
+``grid_exclusive_max[i] = floor((exclusive_max[i] - 1 - grid_origin[i]) / chunk_shape[i])``
+
+The identifier for a chunk with indices ``grid_indices`` is formed by joining
+together the base-10 ASCII string representations of each index (using ``-`` to
+indicate negative indices) using the specified ``separator`` and prefixed with
+the character ``c``. The default value for the ``separator`` is the slash
+character, ``/``, but this may be configured by providing a ``separator`` value
+within the ``chunk_grid`` metadata object (see the section on `Array metadata`_
+below).
 
 For example, in a 3 dimensional array, the identifier for the chunk at
-grid index (1, 23, 45) is the string "c1/23/45".
-
-Note that this specification does not consider the case where the
-chunk grid and the array space are not aligned at the origin vertices
-of the array and the chunk at grid index (0, 0, 0, ...). However,
-extensions may define variations on the regular grid type
-such that the grid indices may include negative integers, and the
-origin vertex of the array may occur at an arbitrary position within
-any chunk, which is required to allow arrays to be extended by an
-arbitrary length in a "negative" direction along any dimension.
+grid index (1, 23, -45) is the string "c1/23/-45".
 
 .. note:: A main difference with spec v2 is that the default chunk separator
    changed from ``.`` to ``/``. This helps with compatibility with N5 as well as
@@ -843,7 +819,7 @@ extensions that affect the layout or interpretation of data
 in the store.
 
 The entry point metadata document must contain a single object
-containing the following names:
+containing the following members:
 
 ``zarr_format``
 ^^^^^^^^^^^^^^^
@@ -947,15 +923,56 @@ Array metadata
 
 Each Zarr array in a hierarchy must have an array metadata
 document. This document must contain a single object with the
-following mandatory names:
+following mandatory members:
 
-``shape``
-^^^^^^^^^
+``domain``
+^^^^^^^^^^
 
-    An array of integers providing the length of each dimension of the
-    Zarr array. For example, a value ``[10, 20]`` indicates a
-    two-dimensional Zarr array, where the first dimension has length
-    10 and the second dimension has length 20.
+    An array of objects specifying the domain_.  The length of the array
+    specifies the number of dimensions_.  Each element of the array must be an
+    object with the following members:
+
+    - ``exclusive_max``: Required.  Integer specifying the exclusive upper bound
+      of the dimension.
+
+    - ``inclusive_min``: Required.  Integer specifying the inclusive lower bound
+      of the dimension.  Must be less than or equal to ``exclusive_max``.
+
+    - ``name``: Optional.  String specifying a dimension name, e.g. ``"x"`` or
+      ``"y"``.  If not specified, defaults to an empty string, ``""``.  A
+      dimension with a non-empty name is considered *named*, while a dimension
+      with an empty name is considered *unnamed*.  Within the domain of a single
+      array, all non-empty dimension names must be distinct (no two dimensions
+      may have the same non-empty name), but more than one dimension may have an
+      empty name.  This specification does not place any restrictions on the use
+      of the same dimension name across multiple arrays within the same
+      hierarchy, but extensions or specific applications may do so.
+
+    Both ``exclusive_max`` and ``inclusive_min`` may be negative integers.  The
+    supported range for ``exclusive_max`` and ``inclusive_min`` is
+    implementation defined, but must be at least ``[-2^-53, +2^53]``.
+
+    For example:
+
+    .. code-block:: json
+
+       [{"inclusive_min": 0, "exclusive_max": 10},
+        {"inclusive_min": 0, "exclusive_max": 20}]
+
+    specifies a 2-dimensional domain where all dimensions are unnamed, the
+    first dimension is indexed by ``0, 1, ..., 9`` and the second dimension is
+    indexed by ``0, 1, ..., 19``.
+
+    As another example:
+
+    .. code-block:: json
+
+       [{"inclusive_min": -5, "exclusive_max": 10, "name": "x"},
+        {"inclusive_min": 7, "exclusive_max": 20, "name": "y"}]
+
+    specifiesa 2-dimensional domain where the first dimension (named ``"x"``) is
+    indexed by ``-5, -4, ..., 9`` and the second dimension (named ``"y"``) is
+    indexed by ``7, 8, ..., 19``.
 
 ``data_type``
 ^^^^^^^^^^^^^
@@ -984,24 +1001,42 @@ following mandatory names:
 ``chunk_grid``
 ^^^^^^^^^^^^^^
 
-    The chunk grid of the Zarr array. If the chunk grid is a regular
-    chunk grid as defined in this specification, then the value must
-    be an object with the names ``type`` and ``chunk_shape``. The
-    value of ``type`` must be the string ``"regular"``, and the value of
-    ``chunk_shape`` must be an array of integers providing the lengths
-    of the chunk along each dimension of the array. For example,
-    ``{"type": "regular", "chunk_shape": [2, 5], "separator":"/"}`` means a regular
-    grid where the chunks have length 2 along the first dimension and
-    length 5 along the second dimension.
+    Specifies how the domain_ of the array is partitioned into chunks.  Must be
+    an object with a ``type`` member, specifying the partitioning method.
+    Additional members are type-specific.
+
+    Supported types are:
+
+    - ``regular``: Specifies a regular chunk grid.  Additional members are:
+
+      - ``chunk_shape``: Required.  Must be an array of positive integers, with
+        length equal to the number of dimensions, specifying the chunk size
+        along each dimension.
+
+      - ``grid_origin``: Optional.  Must be an array of integers, with length
+        equal to the number of dimensions, specifying the origin of the chunk
+        grid within the domain_ of the array.  If not specified, defaults to the
+        zero vector.
+
+      - ``separator``: Optional.  Specifies the separator used to encode grid
+        indices as a storage key.  Must be either ``"/"`` or ``"."``.  If not
+        specified, defaults to ``"/"``.
+
+      For example:
+
+      .. code-block:: json
+
+         {"type": "regular", "chunk_shape": [2, 5], "grid_origin": [1, 3]}
+
+      specifies a grid where the grid cell ``(1, 2)`` corresponds to the region
+      of the domain starting at (inclusive) ``(1 * 2 + 1, 2 * 5 + 3)`` and
+      ending at (exclusive) ``(2 * 1 + 1, 3 * 5 + 3)``.
 
     The ``chunk_grid`` value is an extension point and may be defined
     by an extension. If the chunk grid type is defined by an
-    extension, then the value must be an object containing
-    the names ``extension`` and ``type``. The ``extension`` is
-    required and the value must be a URI that identifies the
+    extension, then the ``type`` must be a URI that identifies the
     extension and dereferences to a human-readable representation of
-    the specification.  The ``type`` is required and the value is
-    defined by the extension.
+    the specification.
 
 ``chunk_memory_layout``
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -1108,7 +1143,10 @@ binary values are laid out in C contiguous order. Each chunk is
 compressed using gzip compression prior to storage::
 
     {
-        "shape": [10000, 1000],
+        "domain": [
+            {"exclusive_max": 10000, "inclusive_min": 0},
+            {"exclusive_max": 1000, "inclusive_min": 0}
+        ],
         "data_type": "<f8",
         "chunk_grid": {
             "type": "regular",
@@ -1131,11 +1169,14 @@ compressed using gzip compression prior to storage::
         }
     }
 
-The following example illustrates an array with the same shape and
+The following example illustrates an array with the same domain and
 chunking as above, but using an extension data type::
 
     {
-        "shape": [10000, 1000],
+        "domain": [
+            {"exclusive_max": 10000, "inclusive_min": 0},
+            {"exclusive_max": 1000, "inclusive_min": 0}
+        ],
         "data_type": {
             "extension": "https://purl.org/zarr/spec/extensions/datetime-dtypes/1.0",
             "type": "<M8[ns]",
@@ -1159,7 +1200,8 @@ chunking as above, but using an extension data type::
     }
 
 .. note::
-   comparison with spec v2,
+   compared with spec v2,
+   ``shape`` has been replaced by ``domain``,
    ``dtype`` has been renamed to ``data_type``,
    ``chunks`` has been renamed to ``chunk_grid``,
    ``order`` has been renamed to ``chunk_memory_layout``,

--- a/docs/core/v3.0.rst
+++ b/docs/core/v3.0.rst
@@ -970,7 +970,7 @@ following mandatory members:
        [{"inclusive_min": -5, "exclusive_max": 10, "name": "x"},
         {"inclusive_min": 7, "exclusive_max": 20, "name": "y"}]
 
-    specifiesa 2-dimensional domain where the first dimension (named ``"x"``) is
+    specifies a 2-dimensional domain where the first dimension (named ``"x"``) is
     indexed by ``-5, -4, ..., 9`` and the second dimension (named ``"y"``) is
     indexed by ``7, 8, ..., 19``.
 


### PR DESCRIPTION
This adds support for dimension names (https://github.com/zarr-developers/zarr-specs/issues/73) and non-zero origins (https://github.com/zarr-developers/zarr-specs/issues/122).