### PR TITLE
Require `fill_value` to be defined

### DIFF
--- a/docs/core/v3.0.rst
+++ b/docs/core/v3.0.rst
@@ -1033,7 +1033,9 @@ following mandatory names:
 
     For any data type, the ``fill_value`` is required. The literal
     ``null`` is not permitted. The fill value needs to be defined
-    so that the data is independent of implementation details.
+    so that the data is independent of implementation details. Internally
+    implementations may provide a default ``fill_value``, but that must
+    be converted to a fixed value in the stored metadata.
 
     If the ``data_type`` of an array is defined in a ``data_type`` extension,
     then said extension is responsible for interpreting the value of

--- a/docs/core/v3.0.rst
+++ b/docs/core/v3.0.rst
@@ -1031,10 +1031,9 @@ following mandatory names:
     value must be a number with no fraction or exponent part and must
     be within the range of the data type.
 
-    For any data type, if the ``fill_value`` is the literal ``null``
-    then the fill value is undefined and the implementation may use
-    any arbitrary value that is consistent with the data type as the
-    fill value.
+    For any data type, the ``fill_value`` is required. The literal
+    ``null`` is not permitted. The fill value needs to be defined
+    so that the data is independent of implementation details.
 
     If the ``data_type`` of an array is defined in a ``data_type`` extension,
     then said extension is responsible for interpreting the value of


### PR DESCRIPTION
Fixes https://github.com/zarr-developers/zarr-specs/issues/133