### PR TITLE
Migrate changes from ZEP1 to main

### DIFF
--- a/docs/core/v3.0.rst
+++ b/docs/core/v3.0.rst
@@ -172,7 +172,7 @@ draft.
 
  - Should core metadata and user attributes be stored together or separate documents?
    (See https://github.com/zarr-developers/zarr-specs/issues/72)
- - extensions and ``must_understand = True`` might be too restrictive. Work a
+ - extensions and ``must_understand = True`` might be too restrictive.
    We propose to develop a draft implementation with extensions and
    see how far we can go. A possible list of extensions to include:
 

--- a/docs/core/v3.0.rst
+++ b/docs/core/v3.0.rst
@@ -38,8 +38,7 @@ This specification defines the Zarr format for N-dimensional typed arrays.
 Status of this document
 =======================
 
-This document is a **Work in Progress**. It may be updated, replaced
-or obsoleted by other documents at any time.
+This document is a draft for review. See `ZEP0001 <https://zarr.dev/zeps/draft/ZEP0001.html>`_ for further information.
 
 Comments, questions or contributions to this document are very
 welcome. Comments and questions should be raised via `GitHub issues

--- a/docs/core/v3.0.rst
+++ b/docs/core/v3.0.rst
@@ -1266,7 +1266,7 @@ The store operations are grouped into three sets of capabilities:
 **readable**, **writeable** and **listable**. It is not necessary for
 a store implementation to support all of these capabilities.
 
-A **readable store** supports the following operation:
+A **readable store** supports the following operations:
 
 
 ``get`` - Retrieve the `value` associated with a given `key`.

--- a/docs/core/v3.0.rst
+++ b/docs/core/v3.0.rst
@@ -1268,7 +1268,6 @@ a store implementation to support all of these capabilities.
 
 A **readable store** supports the following operation:
 
-@@TODO add bundled & partial access
 
 ``get`` - Retrieve the `value` associated with a given `key`.
 


### PR DESCRIPTION
This cherry-picks the first (smaller) [changes from the ZEP1 review PR](https://github.com/zarr-developers/zarr-specs/pull/149/commits) to the `main` branch. The commits included are
3a29e362a30f68dd7d6738380a9d35980911d6a5 dbddeb47d38759692161f34c9b6b1b3bc7764c0d 978cbd2283f56130ffcbb798937c5e86470430bc b63e64dcf530f195b19691e06a44c85916f33291.