### PR TITLE
Core Spec: Allow multiple fallback values for data type

### DIFF
--- a/docs/core/v3.0.rst
+++ b/docs/core/v3.0.rst
@@ -1037,12 +1037,14 @@ following mandatory names:
     the specification.  The ``type`` is required and its value is
     defined by the extension. The ``fallback`` is optional
     and, if provided, its value must be one of the data type
-    identifiers defined in this specification. If an implementation
-    does not recognise the extension, but a ``fallback`` is present,
-    then the implementation may proceed using the ``fallback`` value
-    as the data type. For fallback types that do not correspond to base
-    known types, extensions can fallback on a raw number of bytes using
-    the raw type (``r*``).
+    identifiers defined in this specification, or a list of identifiers
+    from the extension or the core specifiaction where the last fallback
+    value should be a data type identifier of this core specification. If
+    an implementation does not recognise the extension or specific data
+    type, but a ``fallback`` is present, then the implementation may proceed
+    using the first known ``fallback`` value as the data type. If no fallback
+    types are given or they do not correspond to base known types, extensions
+    can fallback on a raw number of bytes using the raw type (``r*``).
 
 ``chunk_grid``
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR allows to have a list of fallback data types for extensions, where all but the last may stem from the extension as well. This allows implementations to add only basic support for an extension, if multiple data types are defined. We might even want to relax this and allow any data types from any other extensions. Probably the data type name should be unique across extensions anyways, so this would be easy to change.

Fixes issue #33, please also see the thread there.