### PR TITLE
Add Jeremy as core spec author

### DIFF
--- a/docs/core/v3.0.rst
+++ b/docs/core/v3.0.rst
@@ -14,7 +14,7 @@ Specification URI:
 Editors:
     * Alistair Miles (`@alimanfoo <https://github.com/alimanfoo>`_), Wellcome Sanger Institute
     * Jonathan Striebel (`@jstriebel <https://github.com/jstriebel>`_), Scalable Minds
-    * Jeremy Maitin-Shepard (`@jbms <https://github.com/jbms>_`), Google
+    * Jeremy Maitin-Shepard (`@jbms <https://github.com/jbms>`_), Google
 
 Issue tracking:
     `GitHub issues <https://github.com/zarr-developers/zarr-specs/labels/core-spec-v3.0>`_

--- a/docs/core/v3.0.rst
+++ b/docs/core/v3.0.rst
@@ -14,6 +14,7 @@ Specification URI:
 Editors:
     * Alistair Miles (`@alimanfoo <https://github.com/alimanfoo>`_), Wellcome Sanger Institute
     * Jonathan Striebel (`@jstriebel <https://github.com/jstriebel>`_), Scalable Minds
+    * Jeremy Maitin-Shepard (`@jbms <https://github.com/jbms>_`), Google
 
 Issue tracking:
     `GitHub issues <https://github.com/zarr-developers/zarr-specs/labels/core-spec-v3.0>`_


### PR DESCRIPTION
As discussed with @joshmoore, we'd like to add @jbms as a core spec author, since he is actively involved in the discussions around it and contributed to the core spec with substantial [PRs](https://github.com/zarr-developers/zarr-specs/pulls?q=is%3Apr+author%3Ajbms).