### PR TITLE
Global storage transformers

### DIFF
--- a/docs/core/v3.0.rst
+++ b/docs/core/v3.0.rst
@@ -445,12 +445,14 @@ terminology for a use case of reading from an array:
 
 *Storage transformer*
 
-    To provide performance enhancements or other optimizations,
+    To provide performance enhancements, optimizations, or additional features,
     storage transformers may intercept and alter the storage keys and bytes
-    of an array_ before they reach the underlying physical storage.
+    of a store before making queries against the physical storage layer.
     Upon retrieval, the original keys and bytes are restored within the
-    transformer. Any number of `predefined storage transformers`_ can be
-    registered and stacked. In contrast to codecs, strorage transformers can
+    transformer.
+    Storage transformers can act globally, for an entire store, or for an
+    individual array_. Any number of `predefined storage transformers`_ can be
+    registered and stacked. In contrast to codecs, array storage transformers
     act on the a complete array, rather than individual chunks. See the
     `storage transformers details`_ below.
 
@@ -904,7 +906,7 @@ Each Zarr hierarchy must have an entry point metadata document, which
 provides essential information regarding the format version being
 used, the encoding being used for group and array metadata, and any
 extensions that affect the layout or interpretation of data
-in the store.
+in the store (including global storage transformers).
 
 The entry point metadata document must contain a single object
 containing the following names:
@@ -973,6 +975,22 @@ containing the following names:
     continue. If the extension is not recognized and the value of
     ``must_understand`` is ``true`` then processing must terminate and
     an appropriate error raised.
+
+The following field is optional:
+
+``storage_transformers``
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+    Specifies a stack of `global storage transformers`_. Each value in the list must
+    be an object containing the names ``extension`` and ``type``.
+    The ``extension`` is required and the value must be a URI that identifies
+    the extension and dereferences to a human-readable representation
+    of the specification.  The ``type`` is required and the value is
+    defined by the extension. The
+    object may also contain a ``configuration`` object which consists of the
+    parameter names and values as defined by the corresponding storage transformer
+    specification. When the ``storage_transformers`` name is absent no storage
+    transformer is used, same for an empty list.
 
 For example, below is an entry point metadata document, specifying that
 JSON is being used for encoding of group and array metadata::
@@ -1150,7 +1168,7 @@ The following members are optional:
 ``storage_transformers``
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-    Specifies a stack of `storage transformers`_. Each value in the list must
+    Specifies a stack of `array storage transformers`_. Each value in the list must
     be an object containing the names ``extension`` and ``type``.
     The ``extension`` is required and the value must be a URI that identifies
     the extension and dereferences to a human-readable representation
@@ -1687,21 +1705,17 @@ Let "+" be the string concatenation operator.
 Storage transformers
 ====================
 
-A Zarr storage transformer allows to change the zarr-compatible data before storing it.
-The stored transformed data is restored to its original state whenever data is requested
-by the Array. Storage transformers can be configured per array via the
-`storage_transformers`_ name in the `array metadata`_. Storage transformers which do
-not change the storage layout (e.g. for caching) may be specified at runtime without
-adding them to the array metadata.
+The purpose of storage transformers is to insert custom logic between the physical storage
+layer and the high-level Zarr data model.
+A storage transformer implements the same `abstract store interface`_ as a store_ and thus
+appears functionally identical to a store from the perspetive of the higher layers of the stack.
+However, it does not permantently store any information necessary to retrieve the original data.
+Instead, it modifies the keys and / or values through some transformation before passing
+them along to the underyling physical storage (or next storage transformer in the chain.)
+Upon retrieval, it reverses its transformation to restore the original keys and values.
 
-A storage transformer serves the same `abstract store interface`_ as the store_.
-However, it should not persistently store any information necessary to restore the original data,
-but instead propagates this to the next storage transformer or the final store.
-From the perspective of an array or a previous stage transformer both store and storage transformer follow the same
-protocol and can be interchanged regarding the protocol. The behaviour can still be different,
-e.g. requests may be cached or the form of the underlying data can change.
-
-Storage transformers may be stacked to combine different functionalities:
+Because they all implement the store interface, storage transformers may be stacked to
+combine different functionalities:
 
 .. mermaid::
 
@@ -1712,17 +1726,46 @@ Storage transformers may be stacked to combine different functionalities:
       end
       t3 --> Store
 
-A fixed set of storage providers is recommended for implementation with this specification:
+
+Global Storage Transformers
+---------------------------
+
+Global storage transformers act on all keys and values in an entire store.
+They are configured for the store via the root metadata document.
+They are suitable for implementing store-wide logic which modifies keys / values
+in a uniform way. Example of features that might be implemented via global storage
+transformers include data version control and content-addressible storage.
 
 
-Predefined storage transformers
--------------------------------
+Array Storage Transformers
+--------------------------
+
+Array storage transformers act on an individual array. They are configured for each array
+via the ``storage_transformers`` name in the `array metadata`_.
+
+A default set of storage transformers is recommended for implementation with this specification:
+
+
+Predefined array storage transformers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - :ref:`sharding-storage-transformer-v1`
 
+
+Runtime Storage Transformers
+----------------------------
+
+Storage transformers which do not change the storage keys may be specified at runtime
+without adding them to the metadata. Caching is a primary example of this:
+if the underlying physical storage is slow (e.g. a remote storage protocol), a caching 
+storage transformer could temporarily save values in a in-memory or local-disk-based cache,
+helping to avoid expensive repeated calls to the remote store.
+Implementations may choose to implement runtime storage transformers on a global or 
+per-array basis.
+
+
 Extensions
 ==========
-
 
 Many types of extensions can exist and they can be grouped as
 following:
@@ -1735,7 +1778,7 @@ array                   ``extensions`` in `Array metadata`_       ``must_underst
 data type               `data_type`_                              no ``fallback``
 chunk grid              `chunk_grid`_                             always
 chunk memory layout     `chunk_memory_layout`_                    always
-storage transformer     `storage_transformers`_                   always
+storage transformer     `Storage transformers`_                   always
 ======================= ========================================= =====================
 
 There are no group extensions in Zarr v3.0.

--- a/docs/core/v3.0.rst
+++ b/docs/core/v3.0.rst
@@ -1733,7 +1733,7 @@ Global Storage Transformers
 Global storage transformers act on all keys and values in an entire store.
 They are configured for the store via the root metadata document.
 They are suitable for implementing store-wide logic which modifies keys / values
-in a uniform way. Example of features that might be implemented via global storage
+in a uniform way. Examples of features that might be implemented via global storage
 transformers include data version control and content-addressible storage.
 
 

--- a/docs/core/v3.0.rst
+++ b/docs/core/v3.0.rst
@@ -1709,7 +1709,7 @@ The purpose of storage transformers is to insert custom logic between the physic
 layer and the high-level Zarr data model.
 A storage transformer implements the same `abstract store interface`_ as a store_ and thus
 appears functionally identical to a store from the perspetive of the higher layers of the stack.
-However, it does not permantently store any information necessary to retrieve the original data.
+However, it does not permanently store any information necessary to retrieve the original data.
 Instead, it modifies the keys and / or values through some transformation before passing
 them along to the underyling physical storage (or next storage transformer in the chain.)
 Upon retrieval, it reverses its transformation to restore the original keys and values.


### PR DESCRIPTION
As discussed in the ZEP call last week, this is a first pass at creating a "global storage transformers" concept, to be applied at the store (rather than array) level.

There are a few things that need cleaning up here:
- [ ] Double check that all RST references point to the right place
- [ ] Add more detail and example use-cases of both global and array storage transformers
- [ ] Add an example of a global storage transformer in `zarr.json`

But before doing that, I thought I would solicit some feedback on this. Does anyone see any fundamental problems with this concept? My motivating use case is #154. 

My main open question is: **when both array and global storage transformers are defined, what determines the order in which they are applied?** The only feasible choices appear to be to apply all the global transformers either _before_ or _after_ the array transformers. Should we make this an option in the protocol?

