### PR TITLE
Fix readthedocs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,4 @@
+version: 2
+
+build:
+  os: ubuntu-22.04

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,3 +2,12 @@ version: 2
 
 build:
   os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+   configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
The [latest readthedocs builds were failing](https://readthedocs.org/projects/zarr-specs/builds/20442359/), as a newer OpenSSL version is required, which is not used in the old default image. This should fix the builds, see https://github.com/readthedocs/readthedocs.org/issues/10290