### PR TITLE
Mark ZEP 1 as accepted.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 <img src="https://github.com/zarr-developers/zarr-logo/releases/download/2022-04-28/zarr-pink-stacked-transparent.png" alt="drawing" height="200"/>
 
-**:warning: The zarr v3 spec is currently a draft and subject to changes.**
 For the v1 and v2 specs, please see
 https://github.com/zarr-developers/zarr-python/tree/main/docs/spec.
 

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -21,3 +21,10 @@ footer {
 .nav-link.nav-external:after {
     display: none;
 }
+
+div.bd-article-container:has(.draft) {
+    background-image: url(../draft-watermark.png) !important;
+    background-repeat: repeat-y !important;
+    background-position: center top !important;
+    background-attachment: scroll !important;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,6 @@ author = 'Zarr Developers'
 extensions = [
   'sphinx.ext.todo',
   'sphinxcontrib.mermaid',
-  'sphinxmark',
   'sphinx_reredirects',
 ]
 
@@ -41,10 +40,6 @@ html_js_files = [
 
 # Display todos by setting to True
 todo_include_todos = True
-
-sphinxmark_enable = True
-sphinxmark_div = 'bd-article-container'
-sphinxmark_image = 'draft-watermark.png'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
 sphinx<6.0.0
 pydata-sphinx-theme==0.12.0
 sphinxcontrib-mermaid
-sphinxmark
 sphinx-reredirects

--- a/docs/v3/codecs/blosc/v1.0.rst
+++ b/docs/v3/codecs/blosc/v1.0.rst
@@ -30,10 +30,7 @@ Defines a ``bytes -> bytes`` codec that uses the blosc container format.
 Status of this document
 =======================
 
-.. warning::
-    This document is a draft for review and subject to changes.
-    It will become final when the `Zarr Enhancement Proposal (ZEP) 1 <https://zarr.dev/zeps/draft/ZEP0001.html>`_
-    is approved via the `ZEP process <https://zarr.dev/zeps/active/ZEP0000.html>`_.
+ZEP0001 was accepted on May 13th, 2023.
 
 
 Document conventions

--- a/docs/v3/codecs/crc32c/v1.0.rst
+++ b/docs/v3/codecs/crc32c/v1.0.rst
@@ -32,6 +32,8 @@ Defines an ``bytes -> bytes`` codec that appends a CRC32C checksum of the input 
 Status of this document
 =======================
 
+.. rst-class:: draft
+
 .. warning::
     This document is a draft for review and subject to changes.
     It will become final when the `Zarr Enhancement Proposal (ZEP) 2 <https://zarr.dev/zeps/draft/ZEP0002.html>`_

--- a/docs/v3/codecs/endian/v1.0.rst
+++ b/docs/v3/codecs/endian/v1.0.rst
@@ -33,10 +33,7 @@ data types as little endian or big endian in lexicographical order.
 Status of this document
 =======================
 
-.. warning::
-    This document is a draft for review and subject to changes.
-    It will become final when the `Zarr Enhancement Proposal (ZEP) 1 <https://zarr.dev/zeps/draft/ZEP0001.html>`_
-    is approved via the `ZEP process <https://zarr.dev/zeps/active/ZEP0000.html>`_.
+ZEP0001 was accepted on May 13th, 2023.
 
 
 Document conventions

--- a/docs/v3/codecs/gzip/v1.0.rst
+++ b/docs/v3/codecs/gzip/v1.0.rst
@@ -30,10 +30,7 @@ Defines a ``bytes -> bytes`` codec that applies gzip compression.
 Status of this document
 =======================
 
-.. warning::
-    This document is a draft for review and subject to changes.
-    It will become final when the `Zarr Enhancement Proposal (ZEP) 1 <https://zarr.dev/zeps/draft/ZEP0001.html>`_
-    is approved via the `ZEP process <https://zarr.dev/zeps/active/ZEP0000.html>`_.
+ZEP0001 was accepted on May 13th, 2023.
 
 
 Document conventions

--- a/docs/v3/codecs/sharding-indexed/v1.0.rst
+++ b/docs/v3/codecs/sharding-indexed/v1.0.rst
@@ -22,6 +22,16 @@ is licensed under a `Creative Commons Attribution 3.0 Unported License
 
 ----
 
+Status of this document
+=======================
+
+.. rst-class:: draft
+
+.. warning::
+    This document is a draft for review and subject to changes.
+    It will become final when the `Zarr Enhancement Proposal (ZEP) 2 <https://zarr.dev/zeps/draft/ZEP0002.html>`_
+    is approved via the `ZEP process <https://zarr.dev/zeps/active/ZEP0000.html>`_.
+
 
 Abstract
 ========

--- a/docs/v3/codecs/transpose/v1.0.rst
+++ b/docs/v3/codecs/transpose/v1.0.rst
@@ -33,10 +33,7 @@ array.
 Status of this document
 =======================
 
-.. warning::
-    This document is a draft for review and subject to changes.
-    It will become final when the `Zarr Enhancement Proposal (ZEP) 1 <https://zarr.dev/zeps/draft/ZEP0001.html>`_
-    is approved via the `ZEP process <https://zarr.dev/zeps/active/ZEP0000.html>`_.
+ZEP0001 was accepted on May 13th, 2023.
 
 
 Document conventions

--- a/docs/v3/core/v3.0.rst
+++ b/docs/v3/core/v3.0.rst
@@ -5,8 +5,6 @@
  Zarr core specification (version 3.0)
 ======================================
 
-  **Editor's draft 25 May 2022**
-
 Specification URI:
     https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html
 
@@ -16,16 +14,13 @@ Editors:
     * Jeremy Maitin-Shepard (`@jbms <https://github.com/jbms>`_), Google
 
 Corresponding ZEP:
-    `ZEP 1 — Zarr specification version 3 <https://zarr.dev/zeps/draft/ZEP0001.html>`_
+    `ZEP 0001 — Zarr specification version 3 <https://zarr.dev/zeps/active/ZEP0001.html>`_
 
 Issue tracking:
     `GitHub issues <https://github.com/zarr-developers/zarr-specs/labels/core-protocol-v3.0>`_
 
 Suggest an edit for this spec:
     `GitHub editor <https://github.com/zarr-developers/zarr-specs/blob/main/docs/v3/core/v3.0.rst>`_
-
-Suggest extensions or other changes as a Zarr Enhancement Proposal (ZEP):
-    `ZEP 0 — Purpose and process <https://zarr.dev/zeps/active/ZEP0000.html>`_
 
 Copyright 2019-Present `Zarr core development team
 <https://github.com/orgs/zarr-developers/teams/core-devs>`_. This work
@@ -44,10 +39,7 @@ This specification defines the Zarr format for N-dimensional typed arrays.
 Status of this document
 =======================
 
-.. warning::
-    This document is a draft for review and subject to changes.
-    It will become final when the `Zarr Enhancement Proposal (ZEP) 1 <https://zarr.dev/zeps/draft/ZEP0001.html>`_
-    is approved via the `ZEP process <https://zarr.dev/zeps/active/ZEP0000.html>`_.
+ZEP0001 was accepted on May 13th, 2023.
 
 
 Introduction

--- a/docs/v3/stores/filesystem/v1.0.rst
+++ b/docs/v3/stores/filesystem/v1.0.rst
@@ -4,10 +4,10 @@
  File system store (version 1.0)
 =================================
 
-  **Editor's draft 26 July 2019**
-
 Specification URI:
     https://zarr-specs.readthedocs.io/en/latest/v3/stores/filesystem/v1.0.html
+Corresponding ZEP:
+    `ZEP 1 — Zarr specification version 3 <https://zarr.dev/zeps/draft/ZEP0001.html>`_
 Issue tracking:
     `GitHub issues <https://github.com/zarr-developers/zarr-specs/labels/stores-filesystem-v1.0>`_
 Suggest an edit for this spec:
@@ -31,18 +31,7 @@ store API using a file system.
 Status of this document
 =======================
 
-.. warning::
-    This document is a draft for review and subject to changes.
-    It will become final when the `Zarr Enhancement Proposal (ZEP) 1 <https://zarr.dev/zeps/draft/ZEP0001.html>`_
-    is approved via the `ZEP process <https://zarr.dev/zeps/active/ZEP0000.html>`_.
-
-Comments, questions or contributions to this document are very
-welcome. Comments and questions should be raised via `GitHub issues
-<https://github.com/zarr-developers/zarr-specs/labels/stores-filesystem-v1.0>`_. When
-raising an issue, please add the label "stores-filesystem-v1.0".
-
-This document was produced by the `Zarr core development team
-<https://github.com/orgs/zarr-developers/teams/core-devs>`_.
+ZEP0001 was accepted on May 13th, 2023.
 
 
 Notes about design decisions for the native File System Store 


### PR DESCRIPTION
* Remove sphinxmark extension.
* Add custom draft mark mechanism to ZEP 2 pages.
* Update status of specs and consolidate headers.

Built upon https://github.com/zarr-developers/zarr-specs/pull/258.

Previews:
* Core Spec (without draft mark): https://zarr-specs--260.org.readthedocs.build/en/260/v3/core/v3.0.html
* Sharding Spec (with draft mark): https://zarr-specs--260.org.readthedocs.build/en/260/v3/codecs/sharding-indexed/v1.0.html