### PR TITLE
Update V3 status and minor fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Zarr Specs
+# Zarr Specification
 
 **Zarr core protocol for storage and retrieval of N-dimensional typed arrays**
 

--- a/docs/v3/codecs/blosc/v1.0.rst
+++ b/docs/v3/codecs/blosc/v1.0.rst
@@ -7,14 +7,13 @@
 Specification URI:
     https://zarr-specs.readthedocs.io/en/latest/v3/codecs/blosc/v1.0.html
 Corresponding ZEP:
-    `ZEP 1 — Zarr specification version 3 <https://zarr.dev/zeps/draft/ZEP0001.html>`_
+    `ZEP0001 — Zarr specification version 3 <https://zarr.dev/zeps/accepted/ZEP0001.html>`_
 Issue tracking:
     `GitHub issues <https://github.com/zarr-developers/zarr-specs/labels/codec>`_
 Suggest an edit for this spec:
     `GitHub editor <https://github.com/zarr-developers/zarr-specs/blob/main/docs/v3/codecs/blosc/v1.0.rst>`_
 
-Copyright 2020 `Zarr core development team
-<https://github.com/orgs/zarr-developers/teams/core-devs>`_. This work
+Copyright 2020-Present Zarr core development team. This work
 is licensed under a `Creative Commons Attribution 3.0 Unported License
 <https://creativecommons.org/licenses/by/3.0/>`_.
 
@@ -30,7 +29,7 @@ Defines a ``bytes -> bytes`` codec that uses the blosc container format.
 Status of this document
 =======================
 
-ZEP0001 was accepted on May 13th, 2023.
+ZEP0001 was accepted on May 15th, 2023 via https://github.com/zarr-developers/zarr-specs/issues/227.
 
 
 Document conventions

--- a/docs/v3/codecs/endian/v1.0.rst
+++ b/docs/v3/codecs/endian/v1.0.rst
@@ -9,14 +9,13 @@
 Specification URI:
     https://zarr-specs.readthedocs.io/en/latest/v3/codecs/endian/v1.0.html
 Corresponding ZEP:
-    `ZEP 1 — Zarr specification version 3 <https://zarr.dev/zeps/draft/ZEP0001.html>`_
+    `ZEP0001 — Zarr specification version 3 <https://zarr.dev/zeps/accepted/ZEP0001.html>`_
 Issue tracking:
     `GitHub issues <https://github.com/zarr-developers/zarr-specs/labels/codec>`_
 Suggest an edit for this spec:
     `GitHub editor <https://github.com/zarr-developers/zarr-specs/blob/main/docs/v3/codecs/endian/v1.0.rst>`_
 
-Copyright 2020 `Zarr core development team
-<https://github.com/orgs/zarr-developers/teams/core-devs>`_. This work
+Copyright 2020-Present Zarr core development team. This work
 is licensed under a `Creative Commons Attribution 3.0 Unported License
 <https://creativecommons.org/licenses/by/3.0/>`_.
 
@@ -33,7 +32,7 @@ data types as little endian or big endian in lexicographical order.
 Status of this document
 =======================
 
-ZEP0001 was accepted on May 13th, 2023.
+ZEP0001 was accepted on May 15th, 2023 via https://github.com/zarr-developers/zarr-specs/issues/227.
 
 
 Document conventions

--- a/docs/v3/codecs/gzip/v1.0.rst
+++ b/docs/v3/codecs/gzip/v1.0.rst
@@ -7,14 +7,13 @@
 Specification URI:
     https://zarr-specs.readthedocs.io/en/latest/v3/codecs/gzip/v1.0.html
 Corresponding ZEP:
-    `ZEP 1 — Zarr specification version 3 <https://zarr.dev/zeps/draft/ZEP0001.html>`_
+    `ZEP0001 — Zarr specification version 3 <https://zarr.dev/zeps/accepted/ZEP0001.html>`_
 Issue tracking:
     `GitHub issues <https://github.com/zarr-developers/zarr-specs/labels/codec>`_
 Suggest an edit for this spec:
     `GitHub editor <https://github.com/zarr-developers/zarr-specs/blob/main/docs/v3/codecs/gzip/v1.0.rst>`_
 
-Copyright 2020 `Zarr core development team
-<https://github.com/orgs/zarr-developers/teams/core-devs>`_. This work
+Copyright 2020-Present Zarr core development team. This work
 is licensed under a `Creative Commons Attribution 3.0 Unported License
 <https://creativecommons.org/licenses/by/3.0/>`_.
 
@@ -30,7 +29,7 @@ Defines a ``bytes -> bytes`` codec that applies gzip compression.
 Status of this document
 =======================
 
-ZEP0001 was accepted on May 13th, 2023.
+ZEP0001 was accepted on May 15th, 2023 via https://github.com/zarr-developers/zarr-specs/issues/227.
 
 
 Document conventions

--- a/docs/v3/codecs/transpose/v1.0.rst
+++ b/docs/v3/codecs/transpose/v1.0.rst
@@ -9,14 +9,13 @@
 Specification URI:
     https://zarr-specs.readthedocs.io/en/latest/v3/codecs/transpose/v1.0.html
 Corresponding ZEP:
-    `ZEP 1 — Zarr specification version 3 <https://zarr.dev/zeps/draft/ZEP0001.html>`_
+    `ZEP0001 — Zarr specification version 3 <https://zarr.dev/zeps/draft/ZEP0001.html>`_
 Issue tracking:
     `GitHub issues <https://github.com/zarr-developers/zarr-specs/labels/codec>`_
 Suggest an edit for this spec:
     `GitHub editor <https://github.com/zarr-developers/zarr-specs/blob/main/docs/v3/codecs/transpose/v1.0.rst>`_
 
-Copyright 2020 `Zarr core development team
-<https://github.com/orgs/zarr-developers/teams/core-devs>`_. This work
+Copyright 2020-Present Zarr core development team. This work
 is licensed under a `Creative Commons Attribution 3.0 Unported License
 <https://creativecommons.org/licenses/by/3.0/>`_.
 
@@ -33,7 +32,7 @@ array.
 Status of this document
 =======================
 
-ZEP0001 was accepted on May 13th, 2023.
+ZEP0001 was accepted on May 15th, 2023 via https://github.com/zarr-developers/zarr-specs/issues/227.
 
 
 Document conventions

--- a/docs/v3/core/v3.0.rst
+++ b/docs/v3/core/v3.0.rst
@@ -14,7 +14,7 @@ Editors:
     * Jeremy Maitin-Shepard (`@jbms <https://github.com/jbms>`_), Google
 
 Corresponding ZEP:
-    `ZEP 0001 — Zarr specification version 3 <https://zarr.dev/zeps/active/ZEP0001.html>`_
+    `ZEP0001 — Zarr specification version 3 <https://zarr.dev/zeps/accepted/ZEP0001.html>`_
 
 Issue tracking:
     `GitHub issues <https://github.com/zarr-developers/zarr-specs/labels/core-protocol-v3.0>`_
@@ -22,8 +22,7 @@ Issue tracking:
 Suggest an edit for this spec:
     `GitHub editor <https://github.com/zarr-developers/zarr-specs/blob/main/docs/v3/core/v3.0.rst>`_
 
-Copyright 2019-Present `Zarr core development team
-<https://github.com/orgs/zarr-developers/teams/core-devs>`_. This work
+Copyright 2019-Present Zarr core development team. This work
 is licensed under a `Creative Commons Attribution 3.0 Unported License
 <https://creativecommons.org/licenses/by/3.0/>`_.
 
@@ -39,7 +38,7 @@ This specification defines the Zarr format for N-dimensional typed arrays.
 Status of this document
 =======================
 
-ZEP0001 was accepted on May 13th, 2023.
+ZEP0001 was accepted on May 15th, 2023 via https://github.com/zarr-developers/zarr-specs/issues/227.
 
 
 Introduction

--- a/docs/v3/stores/filesystem/v1.0.rst
+++ b/docs/v3/stores/filesystem/v1.0.rst
@@ -7,14 +7,13 @@
 Specification URI:
     https://zarr-specs.readthedocs.io/en/latest/v3/stores/filesystem/v1.0.html
 Corresponding ZEP:
-    `ZEP 1 — Zarr specification version 3 <https://zarr.dev/zeps/draft/ZEP0001.html>`_
+    `ZEP0001 — Zarr specification version 3 <https://zarr.dev/zeps/accepted/ZEP0001.html>`_
 Issue tracking:
     `GitHub issues <https://github.com/zarr-developers/zarr-specs/labels/stores-filesystem-v1.0>`_
 Suggest an edit for this spec:
     `GitHub editor <https://github.com/zarr-developers/zarr-specs/blob/main/docs/v3/stores/filesystem/v1.0.rst>`_
 
-Copyright 2019 `Zarr core development team
-<https://github.com/orgs/zarr-developers/teams/core-devs>`_. This work is
+Copyright 2019-Present Zarr core development team. This work is
 licensed under a `Creative Commons Attribution 3.0 Unported License
 <https://creativecommons.org/licenses/by/3.0/>`_.
 
@@ -31,7 +30,7 @@ store API using a file system.
 Status of this document
 =======================
 
-ZEP0001 was accepted on May 13th, 2023.
+ZEP0001 was accepted on May 15th, 2023 via https://github.com/zarr-developers/zarr-specs/issues/227.
 
 
 Notes about design decisions for the native File System Store 


### PR DESCRIPTION
Hi everyone. 👋🏻 

Building this on #260.

The changes in this PR are as follows:

- After going through the recent changes introduced by #260, I realised the date for ZEP0001 acceptance was mentioned as 13th May. The actual date for acceptance is 15th May, when the last vote came in. Check [here](https://github.com/zarr-developers/zarr-specs/issues/227#issuecomment-1547851605) and [here](https://zarr.dev/zeps/accepted/ZEP0001.html).

- Also, we're mentioning [Zarr core development team](https://github.com/orgs/zarr-developers/teams/core-devs) in the specification documents. This shows no team members, and this link throws a 404 to anyone outside our GitHub org. I suggest we remove the hyperlink until we make the teams public, which is visible to everyone (especially users outside the org).

Please have a look and let me know your thoughts.

CC: @zarr-developers/zep1-editors @jhamman