### PR TITLE
Rename endian codec to bytes

### DIFF
--- a/docs/v3/codecs/bytes/v1.0.rst
+++ b/docs/v3/codecs/bytes/v1.0.rst
@@ -62,7 +62,11 @@ Configuration parameters
 ========================
 
 endian:
-    Required for multi-byte data types.  A string equal to either ``"big"`` or ``"little"``.
+    Required for data types for which endianness is applicable. For example, 
+    this includes multi-byte data types, such as ``uint16`` and ``int32``, 
+    but not single-byte data types, such as ``uint8`` or ``bool``. 
+    If present, the value MUST be a string equal to either ``"big"`` or 
+    ``"little"``.
 
 
 Format and algorithm

--- a/docs/v3/codecs/bytes/v1.0.rst
+++ b/docs/v3/codecs/bytes/v1.0.rst
@@ -7,13 +7,13 @@
   **Editor's draft 26 July 2019**
 
 Specification URI:
-    https://zarr-specs.readthedocs.io/en/latest/v3/codecs/endian/v1.0.html
+    https://zarr-specs.readthedocs.io/en/latest/v3/codecs/bytes/v1.0.html
 Corresponding ZEP:
     `ZEP 1 — Zarr specification version 3 <https://zarr.dev/zeps/draft/ZEP0001.html>`_
 Issue tracking:
     `GitHub issues <https://github.com/zarr-developers/zarr-specs/labels/codec>`_
 Suggest an edit for this spec:
-    `GitHub editor <https://github.com/zarr-developers/zarr-specs/blob/main/docs/v3/codecs/endian/v1.0.rst>`_
+    `GitHub editor <https://github.com/zarr-developers/zarr-specs/blob/main/docs/v3/codecs/bytes/v1.0.rst>`_
 
 Copyright 2020 `Zarr core development team
 <https://github.com/orgs/zarr-developers/teams/core-devs>`_. This work
@@ -27,7 +27,8 @@ Abstract
 ========
 
 Defines an ``array -> bytes`` codec that encodes arrays of fixed-size numeric
-data types as little endian or big endian in lexicographical order.
+data types as a sequence of bytes in lexicographical order. For multi-byte data
+types, it encodes the array either in little endian or big endian.
 
 
 Status of this document
@@ -55,14 +56,14 @@ this specification are introduced with the words "for example".
 Codec name
 ==========
 
-The value of the ``name`` member in the codec object MUST be ``endian``.
+The value of the ``name`` member in the codec object MUST be ``bytes``.
 
 
 Configuration parameters
 ========================
 
 endian:
-    Required.  A string equal to either ``"big"`` or ``"little"``.
+    Required for multi-byte data types.  A string equal to either ``"big"`` or ``"little"``.
 
 
 Format and algorithm
@@ -131,4 +132,5 @@ References
 Change log
 ==========
 
-No changes yet.
+- ``endian`` codec was renamed to ``bytes`` codec.  `PR #263
+  <https://github.com/zarr-developers/zarr-specs/pull/263/>`_

--- a/docs/v3/codecs/bytes/v1.0.rst
+++ b/docs/v3/codecs/bytes/v1.0.rst
@@ -1,7 +1,7 @@
-.. _endian-codec-v1:
+.. _bytes-codec-v1:
 
 ============================
- Endian codec (version 1.0)
+ Bytes codec (version 1.0)
 ============================
 
   **Editor's draft 26 July 2019**

--- a/docs/v3/codecs/sharding-indexed/v1.0.rst
+++ b/docs/v3/codecs/sharding-indexed/v1.0.rst
@@ -101,7 +101,7 @@ Sharding can be configured per array in the :ref:`array-metadata` as follows::
             "chunk_shape": [32, 32],
             "codecs": [
               { 
-                "name": "endian",
+                "name": "bytes",
                 "configuration": {
                   "endian": "little",
                 }
@@ -115,7 +115,7 @@ Sharding can be configured per array in the :ref:`array-metadata` as follows::
             ],
             "index_codecs": [
               { 
-                "name": "endian",
+                "name": "bytes",
                 "configuration": {
                   "endian": "little",
                 }

--- a/docs/v3/core/v3.0.rst
+++ b/docs/v3/core/v3.0.rst
@@ -1734,6 +1734,8 @@ by time.
 Changes after Provisional Acceptance
 ------------------------------------
 
+- ``endian`` codec was renamed to ``bytes`` codec.  `PR #263
+  <https://github.com/zarr-developers/zarr-specs/pull/263/>`_
 - Fallback data type support was removed.  `PR #248
   <https://github.com/zarr-developers/zarr-specs/pull/248/>`_
 - It is now required to specify an ``array -> bytes`` codec in the ``codecs``


### PR DESCRIPTION
Renames the `endian` to `bytes` based on this discussion: https://github.com/scalableminds/zarrita/issues/8#issuecomment-1676251849