### PR TITLE
Require transpose codec `order` option to be specified as an explicit permutation

### DIFF
--- a/docs/v3/codecs/transpose/v1.0.rst
+++ b/docs/v3/codecs/transpose/v1.0.rst
@@ -65,15 +65,9 @@ Configuration parameters
 ========================
 
 order:
-    Required.  Must be one of:
-
-    - An array of integers specifying a permutation of ``0``, ``1``, ...,
-      ``n-1``, where ``n`` is the number of dimensions in the decoded chunk
-      representation provided as input to this codec.
-    - The string ``"C"``, equivalent to specifying the identity permutation
-      ``0``, ``1``, ..., ``n-1``.  This makes the codec a no-op.
-    - The string ``"F"``, equivalent to specifying the permutation ``n-1``, ...,
-      ``1``, ``0``.
+    Required.  Must be an array of integers specifying a permutation of ``0``, ``1``, ...,
+    `n-1``, where ``n`` is the number of dimensions in the decoded chunk
+    representation provided as input to this codec.
 
 Format and algorithm
 ====================
@@ -105,4 +99,8 @@ References
 Change log
 ==========
 
-No changes yet.
+Changes after acceptance of ZEP 1
+---------------------------------
+
+The ``order`` configuration parameter no longer supports the constants ``"C"``
+or ``"F"`` and must instead always be specified as an explicit permutation.


### PR DESCRIPTION
The "C" and "F" constants were added to emphasize the relationship with the zarr v2 `order` metadata field.  However, these contants are somewhat confusing:

- "C" means no-op and therefore never needs to be used

- "F" means reverse dimension order.  If there are no other changes to the dimesnion order, this does indeed result in Fortran-order storage, but if there are other changes to the dimension order, that is not the case.  For example, in the following:

```json
"codecs": [
  {"name": "transpose", {"configuration": {"order": "F"}}},
  {"name": "transpose", {"configuration": {"order": "C"}}},
  {"name": "bytes"}
]
```

or

```json
"codecs": [
  {"name": "transpose", {"configuration": {"order": "C"}}},
  {"name": "transpose", {"configuration": {"order": "F"}}},
  {"name": "bytes"}
]
```

the storage order is actually "F", while in the following:

```json
"codecs": [
  {"name": "transpose", {"configuration": {"order": "F"}}},
  {"name": "transpose", {"configuration": {"order": "F"}}},
  {"name": "bytes"}
]
```

the storage order is actually "C".