### PR TITLE
spec: add a motivation for the c prefix on chunk keys

### DIFF
--- a/docs/v3/core/v3.0.rst
+++ b/docs/v3/core/v3.0.rst
@@ -539,7 +539,7 @@ mandatory names:
          in which case the coordinate of a chunk is the empty tuple, and the chunk key
          will consist of the string ``c``.
 
-      .. note:: In the ``default`` ```chunk_key_encoding`` described above, 
+      .. note:: In the ``default`` ``chunk_key_encoding`` described above, 
          chunk keys are stored under the prefix ``c```, which separates chunk keys from 
          the keys for metadata documents. This is a performance optimization that 
          allows applications to find Zarr metadata documents without traversing a 

--- a/docs/v3/core/v3.0.rst
+++ b/docs/v3/core/v3.0.rst
@@ -529,7 +529,7 @@ mandatory names:
 
       For example, in a 3 dimensional array, with a separator of ``/`` the identifier
       for the chunk at grid index (1, 23, 45) is the string ``"c/1/23/45"``.  With a
-      separator of ``.``, the identifier is the string ``"c.1.23.45"``. The inital prefix 
+      separator of ``.``, the identifier is the string ``"c.1.23.45"``. The initial prefix 
       ``c`` ensures that metadata documents and chunks have separate prefixes.
 
       .. note:: A main difference with spec v2 is that the default chunk separator

--- a/docs/v3/core/v3.0.rst
+++ b/docs/v3/core/v3.0.rst
@@ -529,7 +529,8 @@ mandatory names:
 
       For example, in a 3 dimensional array, with a separator of ``/`` the identifier
       for the chunk at grid index (1, 23, 45) is the string ``"c/1/23/45"``.  With a
-      separator of ``.``, the identifier is the string ``"c.1.23.45"``.
+      separator of ``.``, the identifier is the string ``"c.1.23.45"``. The inital prefix 
+      ``c`` ensures that metadata documents and chunks have separate prefixes.
 
       .. note:: A main difference with spec v2 is that the default chunk separator
          changed from ``.`` to ``/``, as in N5.  This decreases the maximum number of
@@ -538,12 +539,6 @@ mandatory names:
       .. note:: Arrays may have 0 dimensions (when for example representing scalars),
          in which case the coordinate of a chunk is the empty tuple, and the chunk key
          will consist of the string ``c``.
-
-      .. note:: In the ``default`` ``chunk_key_encoding`` described above, 
-         chunk keys are stored under the prefix ``c``, which separates chunk keys from 
-         the keys for metadata documents. This is a performance optimization that 
-         allows applications to find Zarr metadata documents without traversing a 
-         potentially large number of chunk keys.
 
     - ``v2``
 

--- a/docs/v3/core/v3.0.rst
+++ b/docs/v3/core/v3.0.rst
@@ -540,7 +540,7 @@ mandatory names:
          will consist of the string ``c``.
 
       .. note:: In the ``default`` ``chunk_key_encoding`` described above, 
-         chunk keys are stored under the prefix ``c```, which separates chunk keys from 
+         chunk keys are stored under the prefix ``c``, which separates chunk keys from 
          the keys for metadata documents. This is a performance optimization that 
          allows applications to find Zarr metadata documents without traversing a 
          potentially large number of chunk keys.

--- a/docs/v3/core/v3.0.rst
+++ b/docs/v3/core/v3.0.rst
@@ -539,6 +539,12 @@ mandatory names:
          in which case the coordinate of a chunk is the empty tuple, and the chunk key
          will consist of the string ``c``.
 
+      .. note:: In the ``default`` ```chunk_key_encoding`` described above, 
+         chunk keys are stored under the prefix ``c```, which separates chunk keys from 
+         the keys for metadata documents. This is a performance optimization that 
+         allows applications to find Zarr metadata documents without traversing a 
+         potentially large number of chunk keys.
+
     - ``v2``
 
       The ``configuration`` object may contain one optional member,


### PR DESCRIPTION
I added a motivation for the `c` prefix on chunk keys. I'm happy to modify this if the reported motivation is factually or stylistically incorrect :)