### PR TITLE
Remove invalid trailing comma in group example

### DIFF
--- a/docs/v3/core/v3.0.rst
+++ b/docs/v3/core/v3.0.rst
@@ -813,7 +813,7 @@ For example, the JSON document below defines an explicit group::
         "node_type": "group",
         "attributes": {
             "spam": "ham",
-            "eggs": 42,
+            "eggs": 42
         }
     }
 


### PR DESCRIPTION
The comma after `"eggs" : 42` is not valid JSON.