### PR TITLE
DOC: Fix v3 spec typo in "operation for retrieving chunk data"  section.

### DIFF
--- a/docs/v3/core/v3.0.rst
+++ b/docs/v3/core/v3.0.rst
@@ -1515,7 +1515,7 @@ Let "+" be the string concatenation operator.
 **Retrieve chunk data in an array**
 
     To retrieve chunk data in an array at path `P` and chunk coordinate (`i`,
-    `j`, ...), perform ``get(data_key(P, j, i, ...), value)``. The returned
+    `j`, ...), perform ``get(data_key(P, j, i, ...))``. The returned
     value is the serialisation of the corresponding chunk, encoded according to
     the array metadata stored at ``meta_key(P)``.
 


### PR DESCRIPTION
In the core v3 spec, in the `Retrieve chunk data in an array` subsection of the `Storage` section, the operation used to demonstrate retrieval of chunk data is incorrect. It should be `get(data_key(P, j, i, ...))` instead of `get(data_key(P, j, i, ...), value)`.