### PR TITLE
Fix error in the v3 spec regarding discovering all nodes using `list_prefix`.

### DIFF
--- a/docs/v3/core/v3.0.rst
+++ b/docs/v3/core/v3.0.rst
@@ -1549,7 +1549,7 @@ Let "+" be the string concatenation operator.
     groups.
 
     For hierarchies without group storage transformers one may also call
-    ``list_prefix("/")``. All ``zarr.json`` keys represent either explicit
+    ``list_prefix("")``. All ``zarr.json`` keys represent either explicit
     groups or arrays. All intermediate prefixes ending in a ``/`` are implicit
     groups.
 


### PR DESCRIPTION
The document mentions using `list_prefix("/")` to discover all nodes in a store. But the spec says that a root node has the empty string prefix. So `list_prefix("/")` would return the empty list since no other non-root node can have have the "/" prefix since all non-root nodes need to have a name. This commit fixes that error by replacing the call to `list_prefix` with the empty string.