### PR TITLE
Fix Example JSON document for Array metadata.

### DIFF
--- a/docs/v3/core/v3.0.rst
+++ b/docs/v3/core/v3.0.rst
@@ -721,9 +721,9 @@ compressed using gzip compression prior to storage::
             }
         },
         "codecs": [{
-            "name": "gzip",
+            "name": "bytes",
             "configuration": {
-                "level": 1
+                "endian": "big"
             }
         }],
         "fill_value": "NaN",
@@ -760,9 +760,9 @@ above, but using a (currently made up) extension data type::
             }
         },
         "codecs": [{
-            "name": "gzip",
+            "name": "bytes",
             "configuration": {
-                "level": 1
+                "endian": "big"
             }
         }],
         "fill_value": null,


### PR DESCRIPTION
JSON array metadata document in the **Array metadata** section is ill-formed. the `codecs` field contains just the gzip codec configuration, even though the spec requires the codec chain to always have one `array->bytes` codec. That is in the example the gzip codec should be replaced with something more sensible like
`{"name": "bytes", "configuration": "big"}` to be considered correct. This commit fixes that.