### PR TITLE
Clarify relationship between the inner chunk shape and shard shape

### DIFF
--- a/docs/v3/codecs/sharding-indexed/v1.0.rst
+++ b/docs/v3/codecs/sharding-indexed/v1.0.rst
@@ -166,7 +166,7 @@ Definitions
 * **Inner chunk** is a chunk within the shard.
 * **Shard shape** is the chunk shape of the outer array.
 * **Inner chunk shape** is defined by the ``chunk_shape`` configuration of the codec.
-  The inner chunk shape needs to have the same dimensions as the shard shape and the 
+  The inner chunk shape needs to have the same number of dimensions as the shard shape and the
   inner chunk shape along each dimension must evenly divide the size of the shard shape.
 * **Chunks per shard** is the element-wise division of the shard shape by the 
   inner chunk shape.


### PR DESCRIPTION
This commit reviews the definitions to enforce that the inner chunk shape must have the same number of dimensions (rather than the same dimensions) as the shard shape with the additional relationship specified by the next sentence.
This change is consistent with the terminology used for the chunk_shape key in the configuration parameters section above