### PR TITLE
Fix data storage key exmaple

### DIFF
--- a/docs/v3/core/v3.0.rst
+++ b/docs/v3/core/v3.0.rst
@@ -408,7 +408,7 @@ underlying store_:
       - Data key
     * - `/foo/baz`
       - `(1, 0)`
-      - `foo/baz/c/1/0`
+      - `foo/baz/1/0`
 
 .. note::
 


### PR DESCRIPTION
Near the top of the spec it says:


> All chunk or other data of an array is stored under the key prefix determined by its path. For a root array, the key prefix is obtained from the metadata document key by stripping the trailing zarr.json. For example, for a root array, the prefix is the empty string. For a non-root array with hierarchy path /foo/bar, the prefix is foo/bar/.

As such, I don't think there should be a `c` level in the example I've edited?