### PR TITLE
Added consolidated metadata to spec

### DIFF
--- a/docs/v3/core/v3.0.rst
+++ b/docs/v3/core/v3.0.rst
@@ -817,16 +817,36 @@ Optional keys:
     must_understand const ``False``            The boolean literal ``False``. Indicates that the field is not required to load the Zarr hierarchy.
     =============== =========================  ===================================================================================================
 
-    Note that *all* children Arrays and Groups should be included in
-    consolidated metadata, not just the nodes immediately below the root Group.
-    Children nested inside other groups should be included too.
-
     Consolidated metadata can help reduce the time needed to load the metadata
     for an entire hierarchy, especially when the metadata is being served over a
     network. Without consolidated metadata, opening an entire hierarchy over the
     network requires an HTTP request per node. Consolidated metadata enables
     loading the metadata for every node in a hierarchy with a single HTTP
     request.
+
+    Note that *all* children Arrays and Groups should be included in
+    consolidated metadata, not just the nodes immediately below the root Group.
+    Children nested inside other groups should be included too as a flat list of
+    nodes. The keys of ``metadata`` should be the path of the node relative to
+    the node at which the metadata is being consolidated (i.e. the ``Group``
+    where this ``consolidated_metadata`` object is stored). For example, given a
+    hierarchy with groups like the following, where capital letters indicate
+    groups: and lowercase letters indicate arrays::
+
+       A/
+         B/
+           C/
+            x
+            y
+
+    If we consolidate the metadata at the Group ``A``, the consolidated metadata
+    would have the keys ``"A", "A/B", "A/B/C", "A/B/C/x", ...``.
+
+    If we consolidate the metadata at the Group ``B``, the consolidated metadata
+    would have the keys ``"C", "C/x", "C/y"``.
+
+    If we consolidate the metadata at the Group ``C``, the consolidated metadata
+    would have the keys ``"x", "y"``.
 
     Consolidated Metadata is optional. If present, then readers should use the
     consolidated metadata when . When not present, readers should use the

--- a/docs/v3/core/v3.0.rst
+++ b/docs/v3/core/v3.0.rst
@@ -821,6 +821,10 @@ Optional keys:
     must_understand const ``False``            The boolean literal ``False``. Indicates that the field is not required to load the Zarr hierarchy.
     =============== =========================  ===================================================================================================
 
+    Note that *all* children Arrays and Groups should be included in
+    consolidated metadata, not just the nodes immediately below the root Group.
+    Children nested inside other groups should be included too.
+
     Consolidated metadata can help reduce the time needed to load the metadata
     for an entire hierarchy, especially when the metadata is being served over a
     network. Without consolidated metadata, opening an entire hierarchy over the

--- a/docs/v3/core/v3.0.rst
+++ b/docs/v3/core/v3.0.rst
@@ -806,6 +806,40 @@ Optional keys:
     pairs, where the key must be a string and the value can be an arbitrary
     JSON literal. Intended to allow storage of arbitrary user metadata.
 
+
+``consolidated_metadata``
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    An object consolidating all the Array and Group metadata of members below
+    the root node in a hierarchy.
+
+    =============== =========================  ===================================================================================================
+    Field           Type                       Description
+    =============== =========================  ===================================================================================================
+    metadata        ``Map<string, Metadata>``  A mapping from node path to Group or Array ``Metadata`` object.
+    kind            const ``'inline'``         The string literal ``'inline'``. Reserved for future use.
+    must_understand const ``False``            The boolean literal ``False``. Indicates that the field is not required to load the Zarr hierarchy.
+    =============== =========================  ===================================================================================================
+
+    Consolidated metadata can help reduce the time needed to load the metadata
+    for an entire hierarchy, especially when the metadata is being served over a
+    network. Without consolidated metadata, opening an entire hierarchy over the
+    network requires an HTTP request per node. Consolidated metadata enables
+    loading the metadata for every node in a hierarchy with a single HTTP
+    request.
+
+    Consolidated Metadata is optional. If present, then readers should use the
+    consolidated metadata when . When not present, readers should use the
+    non-consolidated metadata located in the Store to load the data.
+
+    The ``kind`` field indicates that consolidated metadata is stored inline in
+    the root ``zarr.json`` object. At this time, ``'inline'`` is the only
+    supported value for ``kind``. Future versions of the specification may allow
+    for consolidated metadata in other locations.
+
+Example Group Metadata
+----------------------
+
 For example, the JSON document below defines an explicit group::
 
     {

--- a/docs/v3/core/v3.0.rst
+++ b/docs/v3/core/v3.0.rst
@@ -849,7 +849,7 @@ Optional keys:
     would have the keys ``"x", "y"``.
 
     Consolidated Metadata is optional. If present, then readers should use the
-    consolidated metadata when . When not present, readers should use the
+    consolidated metadata. When not present, readers should use the
     non-consolidated metadata located in the Store to load the data.
 
     The ``kind`` field indicates that consolidated metadata is stored inline in


### PR DESCRIPTION
This PR adds a new optional field to the core metadata for consolidating all the metadata of all child nodes under a single object. The motivation is similar to consolidated metadata in Zarr V2: without consolidated metadata, the time to load metadata for an entire hierarchy scales linearly with the number of nodes. This can be costly, especially for large hierarchies served HTTP from a remote storage system (like Blob Storage).

The primary points to discuss:

1. This currently proposes storing the consolidated metadata in the root `zarr.json` (`kind="inline`). `For *very* large hierarchies, this will bloat the size of the root `zarr.json`, slowing down operations that just want to open the metadata for the root.
2. This overlaps slightly with https://github.com/zarr-developers/zarr-specs/issues/284, which proposes to store the child *paths* (but not full metadata) in the `zarr.json`. That might be a nice alternative to consolidated metadata for very large hierarchies (you could do an initial read to get the list of nodes, and the load the metadata for each child concurrently).
3. Like Zarr v2, consolidated metadata introduces the possibility of "inconsistent" metadata between the consolidated and non-consolidated forms. Should the spec take any stance on how to handle this? I've currently worded things to say that readers should always use the consolidated metadata if it's present.

Closes #136

xref https://github.com/zarr-developers/zarr-python/pull/2113, which is a completed implementation in zarr-python and https://github.com/LDeakin/zarrs/pull/55, a draft implementation in zarrrs..