### PR TITLE
Correct example endianness reference

### DIFF
--- a/docs/v3/core/v3.0.rst
+++ b/docs/v3/core/v3.0.rst
@@ -720,7 +720,7 @@ compressed using gzip compression prior to storage::
         "codecs": [{
             "name": "bytes",
             "configuration": {
-                "endian": "big"
+                "endian": "little"
             }
         }],
         "fill_value": "NaN",


### PR DESCRIPTION
The examples references a "configuration below" as little endian, but the configuration contains:

```json
        "codecs": [{
            "name": "bytes",
            "configuration": {
                "endian": "big"
            }
        }],
```

I assume that this is the right fix. If not, it would be helpful to extend the documentation to provide a more detailed explanation.

In general, it would be helpful to document how endianness works with Zarr 3.

I currently see just the note:

> We are explicitly looking for more feedback and prototypes of code using the r*, raw bits, for various endianness and whether the spec could be made clearer.

And the [Data Types](https://zarr-specs.readthedocs.io/en/latest/v3/data-types.html) page is empty.

@jbms @normanrz @joshmoore @MSanKeys963 