### PR TITLE
Remove inconsistent example description

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,11 +33,6 @@ extensions = [
   'sphinx_reredirects',
 ]
 
-mermaid_version = ""
-html_js_files = [
-   'js/mermaid.js',  # v9.4.0
-]
-
 # Display todos by setting to True
 todo_include_todos = True
 

--- a/docs/v3/core/v3.0.rst
+++ b/docs/v3/core/v3.0.rst
@@ -696,8 +696,7 @@ two-dimensional array of 64-bit little-endian floating point numbers,
 with 10000 rows and 1000 columns, divided into a regular chunk grid where
 each chunk has 1000 rows and 100 columns, and thus there will be 100
 chunks in total arranged into a 10 by 10 grid. Within each chunk the
-binary values are laid out in C contiguous order. Each chunk is
-compressed using gzip compression prior to storage::
+binary values are laid out in C contiguous order::
 
     {
         "zarr_format": 3,


### PR DESCRIPTION
There is nothing in the example specifying compression.

I'm also not sure about the sentence "Within each chunk the binary values are laid out in C contiguous order", because this is the implicit default and does not correspond to anything in the metadata example? Maybe add something about endianness instead?