### PR TITLE
fix: add note about non-object `codecs`

### DIFF
--- a/docs/v3/core/index.rst
+++ b/docs/v3/core/index.rst
@@ -584,11 +584,12 @@ mandatory names:
 
     .. note::
     
-       Zarr v3.1 extended the permitted form of each codec from an object to an
+       Zarr v3.1 extended the permitted form of each codec from an object with
+       a ``name`` and optional ``configuration`` to an
        :ref:`extension-definition`.
-       Implementations should avoid the short-hand string form of an
-       :ref:`extension-definition` in ``codecs`` if backwards compatibility
-       with Zarr v3.0 is required.
+       If backwards compatibility with Zarr v3.0 is required, implementations
+       must not use the ``must_understand`` field or the short-hand name form
+       of an :ref:`extension-definition` in ``codecs``.
 
 Optional
 ^^^^^^^^

--- a/docs/v3/core/index.rst
+++ b/docs/v3/core/index.rst
@@ -586,9 +586,9 @@ mandatory names:
     
        Zarr v3.1 extended the permitted form of each codec from an object to an
        :ref:`extension-definition`.
-       Implementations are encouraged to avoid the short-hand string form of an
-       :ref:`extension-definition` in ``codecs`` if they wish to maintain
-       backwards compatibility with Zarr v3.0.
+       Implementations should avoid the short-hand string form of an
+       :ref:`extension-definition` in ``codecs`` if backwards compatibility
+       with Zarr v3.0 is required.
 
 Optional
 ^^^^^^^^

--- a/docs/v3/core/index.rst
+++ b/docs/v3/core/index.rst
@@ -582,6 +582,14 @@ mandatory names:
     Because ``codecs`` MUST contain an ``array
     -> bytes`` codec, the list cannot be empty (See :ref:`codecs <codecs>`).
 
+    .. note::
+    
+       Zarr v3.1 extended the permitted form of each codec from an object to an
+       :ref:`extension-definition`.
+       Implementations are encouraged to avoid the short-hand string form of an
+       :ref:`extension-definition` in ``codecs`` if they wish to maintain
+       backwards compatibility with Zarr v3.0.
+
 Optional
 ^^^^^^^^
 


### PR DESCRIPTION
See #352.